### PR TITLE
Fix bot logging initialization

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -94,6 +94,7 @@ class ShootyBot(commands.Bot):
                 logging.StreamHandler(sys.stdout),
                 logging.FileHandler("shooty_bot.log", encoding="utf-8"),
             ],
+            force=True,
         )
 
         # Reduce Discord.py logging verbosity


### PR DESCRIPTION
## Summary
- configure logging with `force=True` so earlier logger setup doesn't stop the file handler from being added

## Testing
- `pytest -q` *(fails: TypeError in test_session_commands and multiple assertion errors)*

------
https://chatgpt.com/codex/tasks/task_e_683f8017bb608332bb16ff56e765939a