### PR TITLE
Generate unique session IDs with uuid

### DIFF
--- a/data_manager.py
+++ b/data_manager.py
@@ -2,6 +2,7 @@ import logging
 import json
 import os
 from datetime import datetime, timezone
+import uuid
 from typing import Dict, List, Optional, Any
 from filelock import FileLock
 from config import DATA_DIR
@@ -465,7 +466,7 @@ class DataManager(DatabaseBackedManager[UserData]):
     
     def create_session(self, channel_id: int, started_by: int, game_name: str = None) -> SessionData:
         """Create a new session"""
-        session_id = f"{channel_id}_{int(datetime.now(timezone.utc).timestamp())}"
+        session_id = str(uuid.uuid4())
         session = SessionData(session_id, channel_id, started_by)
         
         # Update game name if provided

--- a/tests/unit/test_data_manager.py
+++ b/tests/unit/test_data_manager.py
@@ -496,7 +496,7 @@ class TestDataManager:
         assert session.started_by == 123456789
         assert session.game_name == "Valorant"
         assert session.session_id in manager.sessions
-        assert session.session_id.startswith("111222333_")
+        assert len(session.session_id) == 36  # UUID4 length
     
     @patch('data_manager.os.makedirs')
     @patch('data_manager.json.dump')


### PR DESCRIPTION
## Summary
- switch session ID creation to uuid4 for guaranteed uniqueness
- adjust unit tests for new ID format

## Testing
- `pytest -q -o addopts=''` *(fails: ModuleNotFoundError and assertion errors)*

------
https://chatgpt.com/codex/tasks/task_e_683f89e493b0833280f2d7d9fc29fca9