### PR TITLE
Fix type for party_status_message helper

### DIFF
--- a/handlers/message_formatter.py
+++ b/handlers/message_formatter.py
@@ -1,4 +1,5 @@
-from typing import Optional, List, Set
+from typing import Optional, List
+from context_manager import ShootyContext
 from config import *
 
 def get_ping_shooty_message(role_code: Optional[str]) -> str:
@@ -24,7 +25,7 @@ def italics(text: str) -> str:
     """Make text italic for Discord"""
     return f"*{text}*"
 
-def party_status_message(is_ping: bool, user_sets: Set[str]) -> str:
+def party_status_message(is_ping: bool, user_sets: ShootyContext) -> str:
     """
     Generate the party status message
     

--- a/tests/unit/handlers/test_message_formatter.py
+++ b/tests/unit/handlers/test_message_formatter.py
@@ -1,5 +1,6 @@
 import pytest
 from unittest.mock import Mock, patch
+from context_manager import ShootyContext
 import sys
 import os
 
@@ -80,7 +81,7 @@ class TestPartyStatusMessage:
     @pytest.fixture
     def mock_user_sets(self):
         """Create a mock ShootyContext object"""
-        user_sets = Mock()
+        user_sets = Mock(spec=ShootyContext)
         user_sets.role_code = "<@&123456789>"
         user_sets.get_party_max_size.return_value = 5
         user_sets.get_user_list_string.return_value = "TestUser1, TestUser2"


### PR DESCRIPTION
## Summary
- import `ShootyContext` in message formatter
- type party_status_message with `ShootyContext`
- adjust message formatter tests to use ShootyContext-spec mocks

## Testing
- `pytest tests/unit/handlers/test_message_formatter.py -q`
- `pytest -q` *(fails: SessionCommands init, context manager, valorant client, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_683f89e291b8833289d152c7a931af71