### PR TITLE
Fix unlink to remove Valorant accounts from DB

### DIFF
--- a/tests/unit/commands/test_valorant_commands.py
+++ b/tests/unit/commands/test_valorant_commands.py
@@ -188,5 +188,29 @@ class TestValorantCommands(unittest.IsolatedAsyncioTestCase):
         # Verify command completed without error
         self.assertTrue(True)
 
+    @patch('valorant_client.database_manager.remove_valorant_account')
+    @patch('valorant_client.data_manager')
+    async def test_unlink_account_removes_database_rows(self, mock_data_manager, mock_remove_account):
+        """Unlinking should remove all Valorant accounts from the database"""
+
+        # Mock user with two linked accounts
+        mock_user = MagicMock()
+        mock_user.get_all_accounts.return_value = [
+            {'username': 'Player1', 'tag': 'NA1'},
+            {'username': 'Player2', 'tag': 'EU1'}
+        ]
+        mock_data_manager.get_user.return_value = mock_user
+
+        from valorant_client import ValorantClient
+        client = ValorantClient()
+
+        result = await client.unlink_account(1111)
+
+        self.assertTrue(result)
+        self.assertEqual(mock_remove_account.call_count, 2)
+        mock_remove_account.assert_any_call(1111, 'Player1', 'NA1')
+        mock_remove_account.assert_any_call(1111, 'Player2', 'EU1')
+        mock_data_manager.save_user.assert_called_once_with(1111)
+
 if __name__ == '__main__':
     unittest.main()

--- a/valorant_client.py
+++ b/valorant_client.py
@@ -161,9 +161,20 @@ class ValorantClient(BaseAPIClient):
         """Unlink a Discord user's Valorant account"""
         try:
             user_data = data_manager.get_user(discord_id)
+
+            # Remove all linked accounts from the database
+            for account in user_data.get_all_accounts():
+                database_manager.remove_valorant_account(
+                    discord_id,
+                    account.get("username"),
+                    account.get("tag"),
+                )
+
+            # Clear cached compatibility fields
             user_data.valorant_username = None
             user_data.valorant_tag = None
             user_data.valorant_puuid = None
+
             data_manager.save_user(discord_id)
             return True
         except Exception as e:


### PR DESCRIPTION
## Summary
- delete Valorant account rows when unlinking
- test unlink removes database rows

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q` *(fails: TypeError, AssertionError, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_683f89e044508332b51ffbc13bd71efe