### PR TITLE
Ensure cleanup commits deletions

### DIFF
--- a/database.py
+++ b/database.py
@@ -1003,14 +1003,15 @@ class DatabaseManager:
                 
                 deleted = conn.execute("""
                     DELETE FROM henrik_matches WHERE match_id IN (
-                        SELECT match_id FROM henrik_matches 
-                        ORDER BY last_accessed ASC 
+                        SELECT match_id FROM henrik_matches
+                        ORDER BY last_accessed ASC
                         LIMIT (SELECT COUNT(*) / 4 FROM henrik_matches)
                     )
                 """).rowcount
-                
+
                 if deleted > 0:
                     logging.info(f"Cleaned up {deleted} old match entries (size limit exceeded)")
+                    conn.commit()
                     
         except Exception as e:
             logging.error(f"Error during match cleanup: {e}")
@@ -1024,14 +1025,15 @@ class DatabaseManager:
             if total_size_mb > max_size_mb:
                 deleted = conn.execute("""
                     DELETE FROM henrik_player_stats WHERE stats_key IN (
-                        SELECT stats_key FROM henrik_player_stats 
-                        ORDER BY last_accessed ASC 
+                        SELECT stats_key FROM henrik_player_stats
+                        ORDER BY last_accessed ASC
                         LIMIT (SELECT COUNT(*) / 4 FROM henrik_player_stats)
                     )
                 """).rowcount
-                
+
                 if deleted > 0:
                     logging.info(f"Cleaned up {deleted} old player stats entries (size limit exceeded)")
+                    conn.commit()
                     
         except Exception as e:
             logging.error(f"Error during player stats cleanup: {e}")
@@ -1045,14 +1047,15 @@ class DatabaseManager:
             if total_size_mb > max_size_mb:
                 deleted = conn.execute("""
                     DELETE FROM henrik_accounts WHERE account_key IN (
-                        SELECT account_key FROM henrik_accounts 
-                        ORDER BY last_accessed ASC 
+                        SELECT account_key FROM henrik_accounts
+                        ORDER BY last_accessed ASC
                         LIMIT (SELECT COUNT(*) / 4 FROM henrik_accounts)
                     )
                 """).rowcount
-                
+
                 if deleted > 0:
                     logging.info(f"Cleaned up {deleted} old account entries (size limit exceeded)")
+                    conn.commit()
                     
         except Exception as e:
             logging.error(f"Error during account cleanup: {e}")

--- a/tests/unit/test_database_cleanup.py
+++ b/tests/unit/test_database_cleanup.py
@@ -1,0 +1,70 @@
+import os
+import json
+from database import DatabaseManager
+
+
+def create_manager(tmp_path):
+    db_path = os.path.join(tmp_path, "test.db")
+    return DatabaseManager(db_path=db_path)
+
+
+def test_match_cleanup_commits(tmp_path):
+    mgr = create_manager(tmp_path)
+    for i in range(4):
+        mgr.store_match(f"m{i}", {"val": i})
+
+    conn = mgr._get_connection()
+    initial = conn.execute("SELECT COUNT(*) FROM henrik_matches").fetchone()[0]
+    assert initial == 4
+
+    mgr._check_and_cleanup_matches(conn, max_size_mb=0)
+    conn.close()
+
+    conn = mgr._get_connection()
+    after = conn.execute("SELECT COUNT(*) FROM henrik_matches").fetchone()[0]
+    conn.close()
+
+    assert after < initial
+
+
+def test_player_stats_cleanup_commits(tmp_path):
+    mgr = create_manager(tmp_path)
+    for i in range(4):
+        mgr.store_player_stats(
+            f"p{i}", "comp", 1, {"score": i}, [
+                {"id": i}
+            ]
+        )
+
+    conn = mgr._get_connection()
+    initial = conn.execute("SELECT COUNT(*) FROM henrik_player_stats").fetchone()[0]
+    assert initial == 4
+
+    mgr._check_and_cleanup_player_stats(conn, max_size_mb=0)
+    conn.close()
+
+    conn = mgr._get_connection()
+    after = conn.execute("SELECT COUNT(*) FROM henrik_player_stats").fetchone()[0]
+    conn.close()
+
+    assert after < initial
+
+
+def test_account_cleanup_commits(tmp_path):
+    mgr = create_manager(tmp_path)
+    for i in range(4):
+        mgr.store_account({"name": f"u{i}", "tag": "NA", "puuid": f"{i}"})
+
+    conn = mgr._get_connection()
+    initial = conn.execute("SELECT COUNT(*) FROM henrik_accounts").fetchone()[0]
+    # Each store_account call creates entries by username_tag and puuid
+    assert initial == 8
+
+    mgr._check_and_cleanup_accounts(conn, max_size_mb=0)
+    conn.close()
+
+    conn = mgr._get_connection()
+    after = conn.execute("SELECT COUNT(*) FROM henrik_accounts").fetchone()[0]
+    conn.close()
+
+    assert after < initial


### PR DESCRIPTION
## Summary
- commit deletions in `_check_and_cleanup_*` helpers
- add tests verifying cleanup commits data removal

## Testing
- `pytest -q tests/unit/test_database_cleanup.py`
- `pytest -q` *(fails: TypeError and assertion errors in unrelated tests)*

------
https://chatgpt.com/codex/tasks/task_e_683f89dbe54083329e8a473bfd92048c