### PR TITLE
Ensure cancelled session retains state

### DIFF
--- a/data_manager.py
+++ b/data_manager.py
@@ -282,9 +282,16 @@ class SessionData(StatefulModel):
                 if len(self.participants) >= self.party_size:
                     self.was_full = True
     
-    def end_session(self):
-        """End the session and calculate duration"""
-        self.state = 'completed'  # Update state
+    def end_session(self, final_state: str = 'completed'):
+        """End the session and calculate duration
+
+        Parameters
+        ----------
+        final_state: str, optional
+            The state to mark the session with once ended. Defaults to
+            ``'completed'``.
+        """
+        self.state = final_state  # Update state
         success = database_manager.end_session(self.session_id, self.was_full)
         if success:
             # Refresh data from database
@@ -294,10 +301,9 @@ class SessionData(StatefulModel):
                 self.duration_minutes = session_data['duration_minutes']
     
     def cancel_session(self):
-        """Cancel the session"""
-        self.state = 'cancelled'
-        # You might want to call end_session here as well
-        self.end_session()
+        """Cancel the session while recording its duration."""
+        # Reuse end_session logic but keep the cancelled state
+        self.end_session(final_state='cancelled')
     
     def to_dict(self) -> Dict[str, Any]:
         """Convert to dictionary for compatibility"""

--- a/tests/unit/test_session_cancellation.py
+++ b/tests/unit/test_session_cancellation.py
@@ -1,0 +1,24 @@
+import pytest
+from freezegun import freeze_time
+
+from data_manager import SessionData
+from database import database_manager
+
+@freeze_time("2024-01-01 12:00:00")
+def test_cancel_session_records_state_and_duration(tmp_path):
+    session = SessionData("cancel_test_session", 111222333, 123456789)
+    # Advance time 30 minutes and cancel
+    with freeze_time("2024-01-01 12:30:00"):
+        session.cancel_session()
+
+    assert session.state == 'cancelled'
+    assert session.end_time == "2024-01-01T12:30:00+00:00"
+    assert session.duration_minutes == 30
+
+    # Ensure persisted values were saved in database
+    stored = database_manager.get_session(session.session_id)
+    assert stored["end_time"] == "2024-01-01T12:30:00+00:00"
+    assert stored["duration_minutes"] == 30
+    # to_dict should reflect the cancelled state
+    data = session.to_dict()
+    assert data["state"] == 'cancelled'


### PR DESCRIPTION
## Summary
- add `final_state` param to `SessionData.end_session`
- keep `cancel_session` state as cancelled while still recording duration
- add regression test covering cancelled sessions

## Testing
- `pytest tests/unit/test_session_cancellation.py -q`
- `pytest -q` *(fails: TypeError in command tests and multiple assertion failures)*

------
https://chatgpt.com/codex/tasks/task_e_683f89d9c5408332b719317bec7cd5dc