### PR TITLE
Fix Henrik timestamp handling

### DIFF
--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,7 +1,8 @@
 import pytest
 from unittest.mock import Mock
 
-from utils import resolve_role, resolve_voice_channel
+from utils import resolve_role, resolve_voice_channel, parse_henrik_timestamp
+from datetime import timezone
 
 
 def _mock_guild():
@@ -45,3 +46,24 @@ def test_resolve_voice_channel_by_name():
     vc.name = "General"
     guild.voice_channels = [vc]
     assert resolve_voice_channel(guild, "General") is vc
+
+
+def test_parse_henrik_timestamp_iso():
+    ts = "2024-01-01T00:00:00Z"
+    dt = parse_henrik_timestamp(ts)
+    assert dt.year == 2024
+    assert dt.tzinfo == timezone.utc
+
+
+def test_parse_henrik_timestamp_epoch_ms():
+    ts_ms = 1609459200000  # 2021-01-01T00:00:00Z
+    dt = parse_henrik_timestamp(ts_ms)
+    assert dt.year == 2021
+    assert dt.tzinfo == timezone.utc
+
+
+def test_parse_henrik_timestamp_epoch_s_string():
+    ts_s = "1609459200"  # 2021-01-01T00:00:00Z
+    dt = parse_henrik_timestamp(ts_s)
+    assert dt.year == 2021
+    assert dt.tzinfo == timezone.utc

--- a/utils.py
+++ b/utils.py
@@ -48,6 +48,27 @@ def format_time_ago(dt: datetime) -> str:
         return "just now"
 
 
+def parse_henrik_timestamp(value: Any) -> Optional[datetime]:
+    """Parse a Henrik API timestamp which may be ISO8601 or UNIX epoch."""
+    if value is None or value == "":
+        return None
+
+    try:
+        # If numeric (or numeric string), treat as epoch seconds or ms
+        if isinstance(value, (int, float)) or (isinstance(value, str) and value.isdigit()):
+            ts = float(value)
+            if ts > 1e12:  # likely milliseconds
+                ts /= 1000.0
+            return datetime.fromtimestamp(ts, tz=timezone.utc)
+
+        if isinstance(value, str):
+            return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except Exception as e:
+        logging.debug(f"Failed to parse timestamp {value}: {e}")
+
+    return None
+
+
 # File/Directory Utilities
 def ensure_directory_exists(path: str) -> None:
     """Ensure directory exists, create if it doesn't."""


### PR DESCRIPTION
## Summary
- add `parse_henrik_timestamp` utility for Henrik API timestamps
- use it in match tracker when parsing match start times
- test timestamp parsing logic

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pytz')*

------
https://chatgpt.com/codex/tasks/task_e_683fc61a5d888332b215eb128d1b92f3