### PR TITLE
Load API key from env

### DIFF
--- a/analyze_multikills.py
+++ b/analyze_multikills.py
@@ -11,7 +11,9 @@ from collections import defaultdict
 def analyze_multikills():
     # Load match data
     match_id = "dae1b62d-c3dd-4663-9131-2771c7f66b5a"
-    api_key = "HDEV-8dad4f6e-ec7b-425c-a34f-74895abdbf19"
+    # Load your Henrik API key from the environment for security. Provide this
+    # via a `.env` file or regular environment variables.
+    api_key = os.getenv("HENRIK_API_KEY")
     
     headers = {"Authorization": api_key}
     url = f"https://api.henrikdev.xyz/valorant/v2/match/{match_id}"

--- a/analyze_timing_multikills.py
+++ b/analyze_timing_multikills.py
@@ -11,7 +11,9 @@ from collections import defaultdict
 def analyze_timing_multikills():
     # Load match data
     match_id = "dae1b62d-c3dd-4663-9131-2771c7f66b5a"
-    api_key = "HDEV-8dad4f6e-ec7b-425c-a34f-74895abdbf19"
+    # API key is pulled from the environment. Set HENRIK_API_KEY in your `.env`
+    # file or OS environment before running.
+    api_key = os.getenv("HENRIK_API_KEY")
     
     headers = {"Authorization": api_key}
     url = f"https://api.henrikdev.xyz/valorant/v2/match/{match_id}"

--- a/calculate_match_stats.py
+++ b/calculate_match_stats.py
@@ -224,7 +224,9 @@ def calculate_stats(match_data):
 def main():
     # Configuration
     match_id = "dae1b62d-c3dd-4663-9131-2771c7f66b5a"
-    api_key = os.getenv("HENRIK_API_KEY", "HDEV-8dad4f6e-ec7b-425c-a34f-74895abdbf19")
+    # Pull the Henrik API key from the environment. Populate HENRIK_API_KEY via
+    # a `.env` file or export it before running this script.
+    api_key = os.getenv("HENRIK_API_KEY")
     
     try:
         print(f"Fetching match data for {match_id}...")

--- a/kast_calibration.py
+++ b/kast_calibration.py
@@ -11,7 +11,9 @@ from calculate_match_stats import get_match_data, calculate_stats
 
 def analyze_kast_differences():
     match_id = "dae1b62d-c3dd-4663-9131-2771c7f66b5a"
-    api_key = "HDEV-8dad4f6e-ec7b-425c-a34f-74895abdbf19"
+    # Get the Henrik API key from the environment. Create a `.env` file or
+    # export HENRIK_API_KEY before running this script.
+    api_key = os.getenv("HENRIK_API_KEY")
     
     match_data = get_match_data(match_id, api_key)
     calculated_stats = calculate_stats(match_data)

--- a/test_match_stats.py
+++ b/test_match_stats.py
@@ -16,7 +16,9 @@ class TestMatchStatsAccuracy(unittest.TestCase):
     def setUpClass(cls):
         """Load match data once for all tests"""
         cls.match_id = "dae1b62d-c3dd-4663-9131-2771c7f66b5a"
-        cls.api_key = os.getenv("HENRIK_API_KEY", "HDEV-8dad4f6e-ec7b-425c-a34f-74895abdbf19")
+        # API key is read from the environment. Set HENRIK_API_KEY in your
+        # environment or `.env` file for tests that require it.
+        cls.api_key = os.getenv("HENRIK_API_KEY")
         
         # Expected values from tracker.gg
         cls.expected_stats = {


### PR DESCRIPTION
## Summary
- remove embedded Henrik API key strings
- load API key from environment variable instead
- document need for `.env`/env variables in comments

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q` *(fails: TypeError, AssertionError, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6840b3bc78dc83329724ebc0abbb0bc4