### PR TITLE
Fix role mention missing in start session ping

### DIFF
--- a/handlers/message_formatter.py
+++ b/handlers/message_formatter.py
@@ -3,11 +3,11 @@ from context_manager import ShootyContext
 from config import *
 
 def get_ping_shooty_message(role_code: Optional[str]) -> str:
-    """Get the initial ping message for starting a session"""
-    if role_code is None:
+    """Get the initial ping message for starting a session."""
+    if not role_code or not role_code.strip():
         return MESSAGES["NO_ROLE"]
-    else:
-        return f"{DEFAULT_MSG}{role_code}"
+
+    return f"{DEFAULT_MSG}{role_code}"
 
 def get_kicked_user_message(kicked_usernames_list: List[str]) -> str:
     """Get message for kicked users"""

--- a/tests/unit/handlers/test_message_formatter.py
+++ b/tests/unit/handlers/test_message_formatter.py
@@ -31,6 +31,12 @@ class TestMessageFormatterHelpers:
         result = get_ping_shooty_message(None)
         expected = "First set the role for the bot to ping with ```$stsr <Role>```"
         assert result == expected
+
+    def test_get_ping_shooty_message_blank_role(self):
+        """Test ping message when role code is blank"""
+        result = get_ping_shooty_message("")
+        expected = "First set the role for the bot to ping with ```$stsr <Role>```"
+        assert result == expected
     
     def test_get_kicked_user_message_single_user(self):
         """Test kicked user message with single user"""


### PR DESCRIPTION
## Summary
- handle blank role codes when building ping message
- test blank-role behavior

## Testing
- `pytest tests/unit/handlers/test_message_formatter.py::TestMessageFormatterHelpers::test_get_ping_shooty_message_with_role tests/unit/handlers/test_message_formatter.py::TestMessageFormatterHelpers::test_get_ping_shooty_message_no_role tests/unit/handlers/test_message_formatter.py::TestMessageFormatterHelpers::test_get_ping_shooty_message_blank_role -q -vv`
- `pytest -q` *(fails: test_context_manager.py etc.)*

------
https://chatgpt.com/codex/tasks/task_e_684122aff94483328b764c23951f9fab