### PR TITLE
Fix match embed duration

### DIFF
--- a/match_tracker.py
+++ b/match_tracker.py
@@ -267,7 +267,8 @@ class MatchTracker:
         
         # Calculate match duration
         if game_length:
-            duration_seconds = game_length // 1000
+            # game_length is already in seconds
+            duration_seconds = int(game_length)
             duration_minutes = duration_seconds // 60
             duration_seconds_remainder = duration_seconds % 60
             

--- a/tests/unit/test_match_duration.py
+++ b/tests/unit/test_match_duration.py
@@ -1,0 +1,75 @@
+import pytest
+from unittest.mock import MagicMock, patch
+import discord
+
+from match_tracker import MatchTracker
+
+
+@pytest.mark.asyncio
+async def test_embed_duration_seconds_to_minutes():
+    bot = MagicMock(spec=discord.Client)
+    tracker = MatchTracker(bot)
+
+    match = {
+        'metadata': {
+            'map': 'Ascent',
+            'rounds_played': 13,
+            'game_length': 90,  # seconds
+            'game_start': '2024-01-01T00:00:00Z',
+            'matchid': 'abc123'
+        },
+        'teams': {
+            'red': {'has_won': True, 'rounds_won': 13},
+            'blue': {'has_won': False, 'rounds_won': 8}
+        }
+    }
+
+    member = MagicMock(spec=discord.Member)
+    member.display_name = 'Player1'
+    discord_members = [
+        {
+            'member': member,
+            'player_data': {'stats': {'kills': 1, 'deaths': 2, 'assists': 3}, 'team': 'red'}
+        }
+    ]
+
+    with patch('match_tracker.format_time_ago', return_value='just now'), \
+         patch.object(tracker, '_calculate_fun_match_stats', return_value={'highlights': [], 'top_performers': {}, 'funny_stats': {}}):
+        embed = await tracker._create_match_embed(match, discord_members)
+
+    assert '1m 30s' in embed.description
+
+
+@pytest.mark.asyncio
+async def test_embed_duration_hours_format():
+    bot = MagicMock(spec=discord.Client)
+    tracker = MatchTracker(bot)
+
+    match = {
+        'metadata': {
+            'map': 'Ascent',
+            'rounds_played': 13,
+            'game_length': 7320,  # seconds -> 2h 2m
+            'game_start': '2024-01-01T00:00:00Z',
+            'matchid': 'abc123'
+        },
+        'teams': {
+            'red': {'has_won': True, 'rounds_won': 13},
+            'blue': {'has_won': False, 'rounds_won': 8}
+        }
+    }
+
+    member = MagicMock(spec=discord.Member)
+    member.display_name = 'Player1'
+    discord_members = [
+        {
+            'member': member,
+            'player_data': {'stats': {'kills': 1, 'deaths': 2, 'assists': 3}, 'team': 'red'}
+        }
+    ]
+
+    with patch('match_tracker.format_time_ago', return_value='just now'), \
+         patch.object(tracker, '_calculate_fun_match_stats', return_value={'highlights': [], 'top_performers': {}, 'funny_stats': {}}):
+        embed = await tracker._create_match_embed(match, discord_members)
+
+    assert '2h 2m' in embed.description


### PR DESCRIPTION
## Summary
- compute game_length directly in seconds when rendering match embed
- add tests for match duration string formatting

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: TestShootyContext.test_bold_readied_user, TestContextManager.test_init_with_data_file, TestContextManager.test_save_context, TestContextManager.test_load_context_data, TestContextManager.test_write_json_atomic_error_handling, TestIntegration.test_multiple_contexts_persistence, TestMatchStatsValidation.test_calculate_player_stats_validation, TestMatchStatsValidation.test_competitive_filtering, TestMatchStatsValidation.test_advanced_stats_validation, test_resolve_voice_channel_by_mention, TestValorantClientInit.test_init_with_api_key, TestValorantClientInit.test_init_without_api_key, TestAccountAPI.test_get_account_info_success, TestAccountAPI.test_get_account_info_error, TestAccountLinking.test_link_account_success, TestGlobalInstance.test_global_instance_exists, TestSessionCommandsUpdated.test_start_session_new, TestSessionCommandsUpdated.test_start_session_with_existing, TestSessionCommandsUpdated.test_mention_session_no_users, TestSessionCommandsUpdated.test_end_session_with_active_session, TestSessionCommandsUpdated.test_end_session_no_active_session, TestScheduledSessionUpdated.test_scheduled_session_success, TestScheduledSessionUpdated.test_scheduled_session_invalid_time)*

------
https://chatgpt.com/codex/tasks/task_e_687ad8abe31483328e5d209dcefdddf1