### PR TITLE
Refactor tests to use shared fixtures

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,6 +36,25 @@ def mock_discord_member():
 
 
 @pytest.fixture
+def discord_member_factory():
+    """Factory to create mock Discord members with custom ids and names"""
+    def _factory(user_id: int = 123456789, name: str = "TestUser"):
+        member = Mock()
+        member.id = user_id
+        member.name = name
+        member.display_name = name
+        member.discriminator = "0001"
+        member.mention = f"<@{user_id}>"
+        member.avatar_url = "https://example.com/avatar.png"
+        member.guild = Mock()
+        member.guild.id = 987654321
+        member.guild.name = "Test Guild"
+        return member
+
+    return _factory
+
+
+@pytest.fixture
 def mock_discord_channel():
     """Create a mock Discord channel object"""
     channel = AsyncMock()

--- a/tests/unit/commands/test_session_commands.py
+++ b/tests/unit/commands/test_session_commands.py
@@ -22,17 +22,11 @@ class TestSessionCommandsUpdated:
             return SessionCommands(mock_bot)
     
     @pytest.fixture
-    def mock_ctx(self):
-        """Create mock Discord context"""
-        ctx = Mock()
-        ctx.channel.id = 123456789
-        ctx.author.id = 987654321
-        ctx.send = AsyncMock()
-        ctx.reply = AsyncMock()
-        ctx.guild = Mock()
-        ctx.guild.name = "Test Guild"
-        ctx.channel.name = "test-channel"
-        return ctx
+    def mock_ctx(self, mock_discord_context):
+        """Use shared mock Discord context fixture"""
+        mock_discord_context.guild.name = "Test Guild"
+        mock_discord_context.channel.name = "test-channel"
+        return mock_discord_context
     
     @patch('commands.session_commands.context_manager')
     @patch('commands.session_commands.data_manager')
@@ -202,14 +196,9 @@ class TestScheduledSessionUpdated:
             return SessionCommands(mock_bot)
     
     @pytest.fixture
-    def mock_ctx(self):
-        """Create mock Discord context"""
-        ctx = Mock()
-        ctx.channel.id = 123456789
-        ctx.author.id = 987654321
-        ctx.send = AsyncMock()
-        ctx.reply = AsyncMock()
-        return ctx
+    def mock_ctx(self, mock_discord_context):
+        """Use shared mock Discord context fixture"""
+        return mock_discord_context
     
     @patch('commands.session_commands.context_manager')
     @patch('commands.session_commands.parser')

--- a/tests/unit/handlers/test_reaction_handler.py
+++ b/tests/unit/handlers/test_reaction_handler.py
@@ -52,10 +52,9 @@ class TestReactionHandler:
         assert result is None
     
     @pytest.mark.asyncio
-    async def test_ignore_non_bot_messages(self, handler):
+    async def test_ignore_non_bot_messages(self, handler, mock_discord_reaction):
         """Test that reactions on non-bot messages are ignored"""
-        reaction = Mock()
-        reaction.message = Mock()
+        reaction = mock_discord_reaction
         reaction.message.author = Mock(id=123456)  # Not the bot
         user = Mock(bot=False)
         
@@ -68,15 +67,14 @@ class TestReactionHandler:
     
     @pytest.mark.asyncio
     @patch('handlers.reaction_handler.context_manager')
-    async def test_ignore_outdated_messages(self, mock_context_manager, handler):
+    async def test_ignore_outdated_messages(self, mock_context_manager, handler, mock_discord_reaction):
         """Test that reactions on outdated messages are ignored"""
         # Setup
         mock_context = Mock()
         mock_context.current_st_message_id = 999
         mock_context_manager.get_context.return_value = mock_context
         
-        reaction = Mock()
-        reaction.message = Mock()
+        reaction = mock_discord_reaction
         reaction.message.id = 123  # Different from current message
         reaction.message.author = handler.bot.user
         reaction.message.channel = Mock(id=111222333)
@@ -137,11 +135,11 @@ class TestReactionHandler:
         mock_data_manager.sessions.get.assert_not_called()
     
     @pytest.mark.asyncio
-    async def test_refresh_status(self, handler):
+    async def test_refresh_status(self, handler, mock_discord_message):
         """Test refresh status functionality"""
         # Setup
-        message = Mock()
-        message.channel = Mock(id=111222333)
+        message = mock_discord_message
+        message.channel.id = 111222333
         
         mock_ctx = AsyncMock()
         handler.bot.get_context = AsyncMock(return_value=mock_ctx)
@@ -159,7 +157,7 @@ class TestReactionHandler:
     
     @pytest.mark.asyncio
     @patch('handlers.reaction_handler.context_manager')
-    async def test_mention_party_no_members(self, mock_context_manager, handler):
+    async def test_mention_party_no_members(self, mock_context_manager, handler, mock_discord_message):
         """Test mention party with no members"""
         # Setup
         mock_context = Mock()
@@ -167,7 +165,7 @@ class TestReactionHandler:
         mock_context.bot_fullstack_user_set = set()
         mock_context_manager.get_context.return_value = mock_context
         
-        message = Mock()
+        message = mock_discord_message
         message.channel = AsyncMock()
         
         # Call the method
@@ -178,19 +176,22 @@ class TestReactionHandler:
     
     @pytest.mark.asyncio
     @patch('handlers.reaction_handler.context_manager')
-    async def test_mention_party_with_members(self, mock_context_manager, handler):
+    async def test_mention_party_with_members(self, mock_context_manager, handler, discord_member_factory, mock_discord_message):
         """Test mention party with members"""
         # Setup
-        user1 = Mock(mention="<@111>", bot=False)
-        user2 = Mock(mention="<@222>", bot=False)
-        bot_user = Mock(mention="<@999>", bot=True)
+        user1 = discord_member_factory(user_id=111, name="User1")
+        user1.bot = False
+        user2 = discord_member_factory(user_id=222, name="User2")
+        user2.bot = False
+        bot_user = discord_member_factory(user_id=999, name="Bot")
+        bot_user.bot = True
         
         mock_context = Mock()
         mock_context.bot_soloq_user_set = {user1, bot_user}
         mock_context.bot_fullstack_user_set = {user2}
         mock_context_manager.get_context.return_value = mock_context
         
-        message = Mock()
+        message = mock_discord_message
         message.channel = AsyncMock()
         
         # Call the method

--- a/tests/unit/test_context_manager.py
+++ b/tests/unit/test_context_manager.py
@@ -21,15 +21,13 @@ class TestShootyContext:
         assert context.party_max_size == 5  # DEFAULT_PARTY_SIZE
         assert context._backup is None
     
-    def test_backup_and_restore_state(self, mock_discord_user):
+    def test_backup_and_restore_state(self, mock_discord_user, discord_member_factory):
         """Test backup and restore functionality"""
         context = ShootyContext(12345)
         
         # Add some users
-        user1 = Mock()
-        user1.name = "User1"
-        user2 = Mock()
-        user2.name = "User2"
+        user1 = discord_member_factory(name="User1")
+        user2 = discord_member_factory(name="User2")
         
         context.add_soloq_user(user1)
         context.add_fullstack_user(user2)
@@ -62,13 +60,13 @@ class TestShootyContext:
         assert restored is False
         assert context._backup is None
     
-    def test_reset_users(self):
+    def test_reset_users(self, discord_member_factory):
         """Test resetting all user sets"""
         context = ShootyContext(12345)
         
         # Add some users
-        user1 = Mock()
-        user2 = Mock()
+        user1 = discord_member_factory()
+        user2 = discord_member_factory()
         
         context.bot_soloq_user_set.add(user1)
         context.bot_fullstack_user_set.add(user2)
@@ -81,11 +79,11 @@ class TestShootyContext:
         assert len(context.bot_fullstack_user_set) == 0
         assert len(context.bot_ready_user_set) == 0
     
-    def test_soloq_user_functions(self):
+    def test_soloq_user_functions(self, discord_member_factory):
         """Test solo queue user management"""
         context = ShootyContext(12345)
-        user1 = Mock()
-        user2 = Mock()
+        user1 = discord_member_factory()
+        user2 = discord_member_factory()
         
         # Add users
         context.add_soloq_user(user1)
@@ -104,11 +102,11 @@ class TestShootyContext:
         assert context.get_soloq_user_count() == 1
         assert not context.is_soloq_user(user1)
     
-    def test_fullstack_user_functions(self):
+    def test_fullstack_user_functions(self, discord_member_factory):
         """Test fullstack user management"""
         context = ShootyContext(12345)
-        user1 = Mock()
-        user2 = Mock()
+        user1 = discord_member_factory()
+        user2 = discord_member_factory()
         
         # Add users
         context.add_fullstack_user(user1)
@@ -134,13 +132,13 @@ class TestShootyContext:
         context.set_party_max_size(10)
         assert context.get_party_max_size() == 10
     
-    def test_get_unique_user_count(self):
+    def test_get_unique_user_count(self, discord_member_factory):
         """Test unique user counting"""
         context = ShootyContext(12345)
         
-        user1 = Mock()
-        user2 = Mock()
-        user3 = Mock()
+        user1 = discord_member_factory()
+        user2 = discord_member_factory()
+        user3 = discord_member_factory()
         
         context.add_soloq_user(user1)
         context.add_soloq_user(user2)
@@ -148,17 +146,14 @@ class TestShootyContext:
         
         assert context.get_unique_user_count() == 3
     
-    def test_remove_user_from_everything(self):
+    def test_remove_user_from_everything(self, discord_member_factory):
         """Test removing users by name prefix"""
         context = ShootyContext(12345)
         
         # Create users with specific names
-        user1 = Mock()
-        user1.name = "TestUser1"
-        user2 = Mock()
-        user2.name = "TestUser2"
-        user3 = Mock()
-        user3.name = "OtherUser"
+        user1 = discord_member_factory(name="TestUser1")
+        user2 = discord_member_factory(name="TestUser2")
+        user3 = discord_member_factory(name="OtherUser")
         
         # Add users to different sets
         context.add_soloq_user(user1)
@@ -175,7 +170,7 @@ class TestShootyContext:
         assert user1 not in context.bot_soloq_user_set
         assert user2 not in context.bot_fullstack_user_set
     
-    def test_bold_readied_user(self):
+    def test_bold_readied_user(self, discord_member_factory):
         """Test user formatting with ready and Valorant status"""
         # Mock the valorant_client module import
         import sys
@@ -185,8 +180,7 @@ class TestShootyContext:
         mock_valorant_client.valorant_client.is_playing_valorant = Mock(return_value=False)
         
         context = ShootyContext(12345)
-        user = Mock()
-        user.name = "TestUser"
+        user = discord_member_factory(name="TestUser")
         user.__str__ = Mock(return_value="TestUser#1234")
         
         # Test normal user
@@ -206,7 +200,7 @@ class TestShootyContext:
         # Clean up
         del sys.modules['valorant_client']
     
-    def test_get_user_list_string(self):
+    def test_get_user_list_string(self, discord_member_factory):
         """Test formatted user list generation"""
         # Mock the valorant_client module import
         import sys
@@ -218,12 +212,9 @@ class TestShootyContext:
         context = ShootyContext(12345)
         
         # Create users
-        user1 = Mock()
-        user1.name = "User1"
-        user2 = Mock()
-        user2.name = "User2"
-        user3 = Mock()
-        user3.name = "User3"
+        user1 = discord_member_factory(name="User1")
+        user2 = discord_member_factory(name="User2")
+        user3 = discord_member_factory(name="User3")
         
         # Add users to different sets
         context.add_soloq_user(user1)
@@ -388,12 +379,10 @@ class TestHelperFunctions:
         assert context.channel_id == 12345
         assert isinstance(context, ShootyContext)
     
-    def test_to_names_list(self):
+    def test_to_names_list(self, discord_member_factory):
         """Test converting user set to names list"""
-        user1 = Mock()
-        user1.name = "User1"
-        user2 = Mock()
-        user2.name = "User2"
+        user1 = discord_member_factory(name="User1")
+        user2 = discord_member_factory(name="User2")
         
         user_set = {user1, user2}
         names = to_names_list(user_set)
@@ -466,12 +455,11 @@ class TestIntegration:
                 assert final_data["111"]["game_name"] == "Game1"
                 assert final_data["222"]["party_max_size"] == 10
     
-    def test_user_state_transitions(self):
+    def test_user_state_transitions(self, discord_member_factory):
         """Test complex user state transitions"""
         context = ShootyContext(12345)
         
-        user = Mock()
-        user.name = "TestUser"
+        user = discord_member_factory(name="TestUser")
         
         # User joins soloq
         context.add_soloq_user(user)

--- a/tests/unit/test_fun_match_stats.py
+++ b/tests/unit/test_fun_match_stats.py
@@ -6,7 +6,7 @@ from match_tracker import MatchTracker
 
 
 @pytest.mark.asyncio
-async def test_multikill_highlights():
+async def test_multikill_highlights(discord_member_factory):
     bot = MagicMock(spec=discord.Client)
     tracker = MatchTracker(bot)
 
@@ -61,10 +61,8 @@ async def test_multikill_highlights():
         }
     }
 
-    member1 = MagicMock(spec=discord.Member)
-    member1.display_name = 'Player1'
-    member2 = MagicMock(spec=discord.Member)
-    member2.display_name = 'Player2'
+    member1 = discord_member_factory(user_id=1, name='Player1')
+    member2 = discord_member_factory(user_id=2, name='Player2')
 
     discord_members = [
         {'member': member1, 'account': {'puuid': 'p1'}, 'player_data': match_data['players']['all_players'][0]},

--- a/tests/unit/test_match_duration.py
+++ b/tests/unit/test_match_duration.py
@@ -6,7 +6,7 @@ from match_tracker import MatchTracker
 
 
 @pytest.mark.asyncio
-async def test_embed_duration_seconds_to_minutes():
+async def test_embed_duration_seconds_to_minutes(discord_member_factory):
     bot = MagicMock(spec=discord.Client)
     tracker = MatchTracker(bot)
 
@@ -24,8 +24,7 @@ async def test_embed_duration_seconds_to_minutes():
         }
     }
 
-    member = MagicMock(spec=discord.Member)
-    member.display_name = 'Player1'
+    member = discord_member_factory(user_id=1, name='Player1')
     discord_members = [
         {
             'member': member,
@@ -41,7 +40,7 @@ async def test_embed_duration_seconds_to_minutes():
 
 
 @pytest.mark.asyncio
-async def test_embed_duration_hours_format():
+async def test_embed_duration_hours_format(discord_member_factory):
     bot = MagicMock(spec=discord.Client)
     tracker = MatchTracker(bot)
 
@@ -59,8 +58,7 @@ async def test_embed_duration_hours_format():
         }
     }
 
-    member = MagicMock(spec=discord.Member)
-    member.display_name = 'Player1'
+    member = discord_member_factory(user_id=1, name='Player1')
     discord_members = [
         {
             'member': member,


### PR DESCRIPTION
## Summary
- introduce `discord_member_factory` fixture for flexible Discord member mocks
- replace inline mocks in fun match and match duration tests
- reuse shared context and message fixtures in reaction and session command tests
- update context manager tests to leverage new member factory

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: KAST% algorithm error, TypeError in SessionCommandsInit, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_687ade284b6c83329a7e4f72b32995e8