### PR TITLE
Add reaction handler and database logging tests

### DIFF
--- a/tests/unit/test_database_logging.py
+++ b/tests/unit/test_database_logging.py
@@ -1,0 +1,36 @@
+import os
+import pytest
+from unittest.mock import Mock, patch, MagicMock
+from database import DatabaseManager
+
+
+def create_manager(tmp_path):
+    db_path = os.path.join(tmp_path, "test.db")
+    return DatabaseManager(db_path=db_path)
+
+
+def test_create_or_update_user_logs_error(tmp_path):
+    mgr = create_manager(tmp_path)
+    mock_conn = MagicMock()
+    mock_conn.execute.side_effect = Exception("boom")
+    mgr._get_connection = Mock(return_value=mock_conn)
+
+    with patch('database.logging') as mock_logging:
+        result = mgr.create_or_update_user(123)
+        assert result is False
+        mock_logging.error.assert_called()
+        mock_conn.rollback.assert_called_once()
+        mock_conn.close.assert_called_once()
+
+
+def test_get_user_logs_error(tmp_path):
+    mgr = create_manager(tmp_path)
+    mock_conn = MagicMock()
+    mock_conn.execute.side_effect = Exception("boom")
+    mgr._get_connection = Mock(return_value=mock_conn)
+
+    with patch('database.logging') as mock_logging:
+        result = mgr.get_user(321)
+        assert result is None
+        mock_logging.error.assert_called()
+        mock_conn.close.assert_called_once()


### PR DESCRIPTION
## Summary
- extend reaction handler tests for refresh failure and party mention edge cases
- add coverage for database logging when operations raise exceptions

## Testing
- `pytest tests/unit/test_database_logging.py tests/unit/handlers/test_reaction_handler.py::TestReactionHandler::test_refresh_status_missing_cog tests/unit/handlers/test_reaction_handler.py::TestReactionHandler::test_mention_party_deduplicate_and_ignore_bots -q`


------
https://chatgpt.com/codex/tasks/task_e_687ade225c8c8332a7f60e320ef7bc80