### PR TITLE
Move integration tests under pytest

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,7 @@
 [pytest]
-testpaths = tests
+testpaths =
+    tests
+    tests/integration
 python_files = test_*.py
 python_classes = Test*
 python_functions = test_*

--- a/tests/integration/test_accurate_stats.py
+++ b/tests/integration/test_accurate_stats.py
@@ -115,6 +115,3 @@ class TestAccurateStatsIntegration(unittest.TestCase):
         self.assertEqual(first_kill["time"], 3000, "First blood should be earliest by time")
         self.assertEqual(first_kill["killer"], "player2", "Wrong player credited with first blood")
 
-if __name__ == "__main__":
-    # Run tests with detailed output
-    unittest.main(verbosity=2)

--- a/tests/integration/test_database_fast.py
+++ b/tests/integration/test_database_fast.py
@@ -171,6 +171,3 @@ def main():
         traceback.print_exc()
         return 1
 
-if __name__ == "__main__":
-    import sys
-    sys.exit(main())

--- a/tests/integration/test_match_stats.py
+++ b/tests/integration/test_match_stats.py
@@ -160,6 +160,3 @@ class TestMatchStatsAccuracy(unittest.TestCase):
         
         self.assertTrue(all_passed, "Not all stats match tracker.gg values")
 
-if __name__ == "__main__":
-    # Run tests with verbose output
-    unittest.main(verbosity=2)

--- a/tests/integration/test_tracker_urls.py
+++ b/tests/integration/test_tracker_urls.py
@@ -72,6 +72,3 @@ class TestTrackerURLGeneration(unittest.TestCase):
         self.assertTrue(short_link.startswith("[Tracker.gg]("))
         self.assertTrue(short_link.endswith(")"))
 
-if __name__ == "__main__":
-    # Run tests with detailed output
-    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary
- relocate top-level integration test scripts into `tests/integration`
- drop `unittest.main()` blocks so pytest runs them automatically
- update `pytest.ini` so new folder is included in test discovery

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: TypeError __init__ should return None not MagicMock)*

------
https://chatgpt.com/codex/tasks/task_e_687ade209cec83328b29325317fd351f