### PR TITLE
Show untracked teammates in match result squad with in-game tag

### DIFF
--- a/match_tracker.py
+++ b/match_tracker.py
@@ -327,6 +327,7 @@ class MatchTracker:
         stack_result = ""
         team_color = None
         team_won = False
+        tracked_puuids = set()
 
         for dm in discord_members:
             member = dm['member']
@@ -340,12 +341,37 @@ class MatchTracker:
                     team_won = teams[team_color].get('has_won', False)
                 stack_result = "🏆 WON" if team_won else "❌ LOST"
 
+            puuid = dm.get('account', {}).get('puuid') or player_data.get('puuid')
+            if puuid:
+                tracked_puuids.add(puuid)
+
             kda = f"{stats.get('kills', 0)}/{stats.get('deaths', 0)}/{stats.get('assists', 0)}"
             member_list.append(f"• **{member.display_name}**: {kda}")
-        
+
+        # Add untracked teammates (players on the same team who aren't linked via shootylink)
+        all_players = match.get('players', {}).get('all_players', [])
+        untracked_count = 0
+        if team_color:
+            for player in all_players:
+                if player.get('team', '').lower() != team_color:
+                    continue
+                if player.get('puuid') in tracked_puuids:
+                    continue
+                stats = player.get('stats', {})
+                name = player.get('name', 'Unknown')
+                tag = player.get('tag', '')
+                display_name = f"{name}#{tag}" if tag else name
+                kda = f"{stats.get('kills', 0)}/{stats.get('deaths', 0)}/{stats.get('assists', 0)}"
+                member_list.append(f"• **{display_name}**: {kda}")
+                untracked_count += 1
+
+        squad_size = len(discord_members) + untracked_count
+        if not stack_result:
+            stack_result = "🏆 WON" if team_won else "❌ LOST"
+
         embed.add_field(
-            name=f"👥 Squad ({len(discord_members)}) - {stack_result}",
-            value="\n".join(member_list),
+            name=f"👥 Squad ({squad_size}) - {stack_result}",
+            value="\n".join(member_list) if member_list else "No squad members found",
             inline=False
         )
         

--- a/tests/unit/test_untracked_squad_members.py
+++ b/tests/unit/test_untracked_squad_members.py
@@ -1,0 +1,111 @@
+import pytest
+from unittest.mock import MagicMock, patch
+import discord
+
+from match_tracker import MatchTracker
+
+
+@pytest.mark.asyncio
+async def test_untracked_teammates_shown_with_ingame_tag(discord_member_factory):
+    """Untracked teammates should appear in the squad list with their in-game name#tag."""
+    bot = MagicMock(spec=discord.Client)
+    tracker = MatchTracker(bot)
+
+    match = {
+        'metadata': {
+            'map': 'Ascent',
+            'rounds_played': 13,
+            'game_length': 1800,
+            'game_start': '2024-01-01T00:00:00Z',
+            'matchid': 'abc123',
+        },
+        'teams': {
+            'red': {'has_won': True, 'rounds_won': 13},
+            'blue': {'has_won': False, 'rounds_won': 8},
+        },
+        'players': {
+            'all_players': [
+                {'puuid': 'p1', 'name': 'TrackedPlayer', 'tag': 'NA1', 'team': 'Red',
+                 'stats': {'kills': 20, 'deaths': 10, 'assists': 5}},
+                {'puuid': 'p2', 'name': 'RandoTeammate', 'tag': 'EU1', 'team': 'Red',
+                 'stats': {'kills': 15, 'deaths': 12, 'assists': 3}},
+                {'puuid': 'p3', 'name': 'SoloQueueBuddy', 'tag': '420', 'team': 'Red',
+                 'stats': {'kills': 8, 'deaths': 14, 'assists': 7}},
+                {'puuid': 'enemy1', 'name': 'Enemy', 'tag': 'KR1', 'team': 'Blue',
+                 'stats': {'kills': 18, 'deaths': 16, 'assists': 4}},
+            ],
+        },
+    }
+
+    member = discord_member_factory(user_id=1, name='TrackedDisplayName')
+    discord_members = [
+        {
+            'member': member,
+            'account': {'puuid': 'p1'},
+            'player_data': match['players']['all_players'][0],
+        }
+    ]
+
+    with patch('match_tracker.format_time_ago', return_value='just now'), \
+         patch.object(tracker, '_calculate_fun_match_stats',
+                      return_value={'highlights': [], 'top_performers': {}, 'funny_stats': {}}):
+        embed = await tracker._create_match_embed(match, discord_members)
+
+    squad_field = next(f for f in embed.fields if 'Squad' in f.name)
+
+    # Tracked member shown by Discord display name
+    assert 'TrackedDisplayName' in squad_field.value
+    # Untracked teammates shown by in-game name#tag
+    assert 'RandoTeammate#EU1' in squad_field.value
+    assert 'SoloQueueBuddy#420' in squad_field.value
+    # Enemy team is NOT included
+    assert 'Enemy' not in squad_field.value
+    # Squad count reflects tracked + untracked teammates
+    assert 'Squad (3)' in squad_field.name
+
+
+@pytest.mark.asyncio
+async def test_untracked_player_without_tag_falls_back_to_name(discord_member_factory):
+    """If an untracked player has no tag field, display just their name."""
+    bot = MagicMock(spec=discord.Client)
+    tracker = MatchTracker(bot)
+
+    match = {
+        'metadata': {
+            'map': 'Bind',
+            'rounds_played': 13,
+            'game_length': 1800,
+            'game_start': '2024-01-01T00:00:00Z',
+            'matchid': 'xyz',
+        },
+        'teams': {
+            'red': {'has_won': False, 'rounds_won': 8},
+            'blue': {'has_won': True, 'rounds_won': 13},
+        },
+        'players': {
+            'all_players': [
+                {'puuid': 'p1', 'name': 'Tracked', 'tag': 'NA1', 'team': 'Red',
+                 'stats': {'kills': 5, 'deaths': 10, 'assists': 2}},
+                {'puuid': 'p2', 'name': 'NoTagPlayer', 'tag': '', 'team': 'Red',
+                 'stats': {'kills': 7, 'deaths': 9, 'assists': 1}},
+            ],
+        },
+    }
+
+    member = discord_member_factory(user_id=1, name='Tracked')
+    discord_members = [
+        {
+            'member': member,
+            'account': {'puuid': 'p1'},
+            'player_data': match['players']['all_players'][0],
+        }
+    ]
+
+    with patch('match_tracker.format_time_ago', return_value='just now'), \
+         patch.object(tracker, '_calculate_fun_match_stats',
+                      return_value={'highlights': [], 'top_performers': {}, 'funny_stats': {}}):
+        embed = await tracker._create_match_embed(match, discord_members)
+
+    squad_field = next(f for f in embed.fields if 'Squad' in f.name)
+    assert 'NoTagPlayer' in squad_field.value
+    assert 'NoTagPlayer#' not in squad_field.value


### PR DESCRIPTION
## Summary
- Match result embeds previously only listed Discord members linked via `/shootylink`. Teammates of the tracked stack who weren't linked were omitted entirely.
- Now any teammate on the same team as the tracked stack is included in the squad list. Tracked members continue to display their Discord name; untracked teammates display their in-game `name#tag`.
- The squad count and member list both reflect the combined roster. Enemy team players are still excluded.

## Test plan
- [x] `pytest tests/unit/test_untracked_squad_members.py` – new tests for tracked + untracked display and the missing-tag fallback
- [x] `pytest tests/unit/test_match_duration.py tests/unit/test_fun_match_stats.py` – existing embed/stat tests still pass
- [ ] Manual: trigger a real post-match recap with a mix of linked and unlinked teammates and confirm the squad field renders correctly

---
_Generated by [Claude Code](https://claude.ai/code/session_01UKyh3wyDzJV8gTeyhgGqev)_