### PR TITLE
Add voice state update listener to refresh queue messages

### DIFF
--- a/commands/session_commands.py
+++ b/commands/session_commands.py
@@ -28,6 +28,8 @@ class SessionCommands(BaseCommandCog):
 
             channel_id = ctx.channel.id
             shooty_context = context_manager.get_context(channel_id)
+            # Keep a live channel reference so voice-channel presence can be resolved
+            shooty_context.channel = ctx.channel
 
             # End previous session if one exists
             if hasattr(shooty_context, 'current_session_id') and shooty_context.current_session_id:
@@ -89,6 +91,8 @@ class SessionCommands(BaseCommandCog):
 
             channel_id = ctx.channel.id
             shooty_context = context_manager.get_context(channel_id)
+            # Keep a live channel reference so voice-channel presence can be resolved
+            shooty_context.channel = ctx.channel
 
             status_message = party_status_message(False, shooty_context)
             await ctx.reply(status_message)

--- a/context_manager.py
+++ b/context_manager.py
@@ -192,18 +192,22 @@ class ShootyContext:
             return name
     
     def _is_user_in_voice_channel(self, user) -> bool:
-        """Check if user is in the configured voice channel"""
-        if not self.voice_channel_id or not self.channel:
+        """Check if user is connected to any voice channel in the server"""
+        guild = getattr(self.channel, "guild", None) if self.channel else None
+        if guild is None:
             return False
-        
+
         try:
-            # Get the voice channel
-            voice_channel = self.channel.guild.get_channel(self.voice_channel_id)
-            if not voice_channel:
-                return False
-            
-            # Check if user is in the voice channel
-            return user in voice_channel.members
+            # Prefer the member's live voice state when available
+            member = guild.get_member(user.id)
+            if member is not None:
+                return member.voice is not None and member.voice.channel is not None
+
+            # Fallback: scan every voice channel's member list
+            for voice_channel in guild.voice_channels:
+                if user in voice_channel.members:
+                    return True
+            return False
         except Exception:
             return False
     

--- a/handlers/reaction_handler.py
+++ b/handlers/reaction_handler.py
@@ -33,7 +33,9 @@ class ReactionHandler(commands.Cog):
         
         channel_id = reaction.message.channel.id
         shooty_context = context_manager.get_context(channel_id)
-        
+        # Keep a live channel reference so voice-channel presence can be resolved
+        shooty_context.channel = reaction.message.channel
+
         logging.info(
             f"Reaction added: {reaction.emoji} by {user.name} in channel {channel_id}"
         )
@@ -95,7 +97,9 @@ class ReactionHandler(commands.Cog):
         
         channel_id = reaction.message.channel.id
         shooty_context = context_manager.get_context(channel_id)
-        
+        # Keep a live channel reference so voice-channel presence can be resolved
+        shooty_context.channel = reaction.message.channel
+
         logging.info(
             f"Reaction removed: {reaction.emoji} by {user.name} in channel {channel_id}"
         )
@@ -136,6 +140,47 @@ class ReactionHandler(commands.Cog):
 
             await self._update_party_message(reaction.message, shooty_context)
     
+    @commands.Cog.listener()
+    async def on_voice_state_update(
+        self,
+        member: discord.Member,
+        before: discord.VoiceState,
+        after: discord.VoiceState,
+    ) -> None:
+        """Re-render queue messages when a queued user joins/leaves voice."""
+        # Only react to actual channel changes (join, leave, or move)
+        if before.channel == after.channel:
+            return
+
+        refreshed_any = False
+        for shooty_context in context_manager.contexts.values():
+            # Skip channels that have no active message to update
+            if not shooty_context.current_st_message_id:
+                continue
+
+            # Only act if this member is currently queued in this context
+            queued_users = shooty_context.bot_soloq_user_set | shooty_context.bot_fullstack_user_set
+            if member not in queued_users:
+                continue
+
+            channel = self.bot.get_channel(shooty_context.channel_id)
+            if channel is None or getattr(channel, "guild", None) != member.guild:
+                continue
+
+            # Keep the channel reference fresh for voice-presence resolution
+            shooty_context.channel = channel
+            try:
+                message = await channel.fetch_message(shooty_context.current_st_message_id)
+                await self._update_party_message(message, shooty_context)
+                refreshed_any = True
+            except discord.NotFound:
+                logging.info("Skipping voice update - shooty message no longer exists")
+            except discord.HTTPException as e:
+                logging.warning(f"Failed to refresh shooty message on voice update: {e}")
+
+        if refreshed_any:
+            await self.bot.update_status_with_queue_count()
+
     async def _refresh_status(self, message):
         """Refresh the party status message"""
         channel_id = message.channel.id

--- a/tests/unit/handlers/test_reaction_handler.py
+++ b/tests/unit/handlers/test_reaction_handler.py
@@ -253,6 +253,98 @@ class TestReactionHandler:
         assert "<@333>" not in call_args
 
 
+class TestVoiceStateUpdate:
+    """Test cases for the on_voice_state_update listener"""
+
+    @pytest.fixture
+    def handler(self):
+        bot = Mock()
+        bot.user = Mock(id=999999999)
+        bot.get_channel = Mock()
+        bot.update_status_with_queue_count = AsyncMock()
+        return ReactionHandler(bot)
+
+    def _voice_state(self, channel):
+        state = Mock(spec=discord.VoiceState)
+        state.channel = channel
+        return state
+
+    @pytest.mark.asyncio
+    @patch('handlers.reaction_handler.context_manager')
+    async def test_ignores_non_channel_changes(self, mock_context_manager, handler):
+        """Mute/deafen updates (same channel) should not trigger a refresh"""
+        same_channel = Mock()
+        member = Mock(spec=discord.Member)
+
+        await handler.on_voice_state_update(
+            member,
+            self._voice_state(same_channel),
+            self._voice_state(same_channel),
+        )
+
+        handler.bot.get_channel.assert_not_called()
+        handler.bot.update_status_with_queue_count.assert_not_called()
+
+    @pytest.mark.asyncio
+    @patch('handlers.reaction_handler.party_status_message', return_value="updated")
+    @patch('handlers.reaction_handler.context_manager')
+    async def test_refreshes_message_for_queued_member(
+        self, mock_context_manager, mock_status, handler
+    ):
+        """A queued member joining voice should re-render that channel's message"""
+        guild = Mock()
+        member = Mock(spec=discord.Member)
+        member.guild = guild
+
+        context = Mock()
+        context.channel_id = 555
+        context.current_st_message_id = 777
+        context.bot_soloq_user_set = {member}
+        context.bot_fullstack_user_set = set()
+        mock_context_manager.contexts = {555: context}
+
+        message = AsyncMock()
+        channel = AsyncMock()
+        channel.guild = guild
+        channel.fetch_message.return_value = message
+        handler.bot.get_channel.return_value = channel
+
+        await handler.on_voice_state_update(
+            member,
+            self._voice_state(None),
+            self._voice_state(Mock()),
+        )
+
+        channel.fetch_message.assert_awaited_once_with(777)
+        message.edit.assert_awaited_once_with(content="updated")
+        assert context.channel == channel
+        handler.bot.update_status_with_queue_count.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    @patch('handlers.reaction_handler.context_manager')
+    async def test_ignores_member_not_queued(self, mock_context_manager, handler):
+        """A member who is not queued should not trigger any refresh"""
+        guild = Mock()
+        member = Mock(spec=discord.Member)
+        member.guild = guild
+
+        context = Mock()
+        context.channel_id = 555
+        context.current_st_message_id = 777
+        context.bot_soloq_user_set = set()
+        context.bot_fullstack_user_set = set()
+        mock_context_manager.contexts = {555: context}
+
+        await handler.on_voice_state_update(
+            member,
+            self._voice_state(None),
+            self._voice_state(Mock()),
+        )
+
+        handler.bot.get_channel.assert_not_called()
+        handler.bot.update_status_with_queue_count.assert_not_called()
+
+
 @pytest.mark.asyncio
 async def test_setup():
     """Test the setup function"""


### PR DESCRIPTION
## Summary
Adds a new `on_voice_state_update` listener to the ReactionHandler that automatically refreshes queue messages when users join or leave voice channels. This improves the user experience by keeping the party status message up-to-date with real-time voice channel presence.

## Key Changes

- **New voice state listener**: Added `on_voice_state_update` method to ReactionHandler that:
  - Detects when queued members join/leave voice channels
  - Refreshes the party status message for affected channels
  - Updates bot status with current queue count
  - Ignores mute/deafen changes (same channel) and non-queued members

- **Improved voice presence detection**: Enhanced `_is_user_in_voice_channel` in context_manager.py to:
  - Check live member voice state via `member.voice` when available
  - Fall back to scanning voice channel member lists for reliability
  - Work with any voice channel in the guild (not just configured channel)

- **Live channel reference tracking**: Added `shooty_context.channel` assignment in:
  - `on_reaction_add` and `on_reaction_remove` handlers
  - `start_session` and `session_status` commands
  - `on_voice_state_update` listener
  - Ensures voice presence checks can access the guild context

## Implementation Details

The voice state listener iterates through all active contexts and:
1. Skips contexts without an active message to update
2. Checks if the member is queued in that context
3. Validates the channel belongs to the member's guild
4. Fetches and re-renders the party status message
5. Handles `NotFound` and `HTTPException` gracefully
6. Updates bot status only if at least one message was refreshed

Comprehensive unit tests added covering:
- Ignoring non-channel changes (mute/deafen)
- Refreshing messages for queued members
- Ignoring non-queued members

https://claude.ai/code/session_01E6PLtGg9moSQcmDKw4dp3c