### PR TITLE
Add rank/RR integration, head-to-head compare, and session recaps

### DIFF
--- a/commands/session_commands.py
+++ b/commands/session_commands.py
@@ -11,6 +11,7 @@ from context_manager import context_manager
 from handlers.message_formatter import get_ping_shooty_message, party_status_message
 from handlers.reaction_handler import add_react_options
 from data_manager import data_manager
+from match_tracker import get_match_tracker
 from config import MESSAGES, MAX_SCHEDULED_HOURS
 from utils import format_time_for_display
 
@@ -242,6 +243,8 @@ class SessionCommands(BaseCommandCog):
                     "`/shootylink <username> <tag>` - Link Valorant account\n"
                     "`/shootystats [member]` - Show session & game stats\n"
                     "`/shootystatsdetailed [member]` - Detailed match statistics\n"
+                    "`/shootyrank [member]` - Current rank, RR & last game change\n"
+                    "`/shootycompare <p1> [p2]` - Head-to-head stat comparison\n"
                     "`/shootyleaderboard [stat]` - Server leaderboards\n"
                     "`/shootywho` - Who's currently playing Valorant\n"
                     "`/shootyhelp valorant` - See all Valorant commands"
@@ -314,6 +317,8 @@ class SessionCommands(BaseCommandCog):
                 value=(
                     "`/shootystats [member]` - Basic session stats\n"
                     "`/shootystatsdetailed [member] [account]` - Full match analysis\n"
+                    "`/shootyrank [member] [account]` - Current rank, RR & last game change\n"
+                    "`/shootycompare <player1> [player2]` - Head-to-head stat comparison\n"
                     "`/shootyfun [member]` - Fun stats & achievements\n"
                     "`/shootyleaderboard <stat>` - Server rankings\n"
                     "**Available stats:** kda, kd, winrate, headshot, acs, clutch, multikill"
@@ -493,15 +498,46 @@ class SessionCommands(BaseCommandCog):
             shooty_context = context_manager.get_context(channel_id)
 
             if hasattr(shooty_context, 'current_session_id') and shooty_context.current_session_id:
+                # Recap building hits the Valorant API, so defer the slash response
+                await self.defer_if_slash(ctx)
+
+                session_id = shooty_context.current_session_id
+                # Capture participants before _end_current_session resets the stack
+                participants = [
+                    user for user in
+                    shooty_context.bot_soloq_user_set.union(shooty_context.bot_fullstack_user_set)
+                    if not getattr(user, 'bot', False)
+                ]
+
                 await self._end_current_session(shooty_context)
                 # Update bot status after ending session
                 await self.bot.update_status_with_queue_count()
-                await self.send_success_embed(ctx, "Session Ended", "Session ended and stats recorded!")
+
+                # Post an end-of-session recap (best-effort; falls back on failure)
+                if not await self._send_session_recap(ctx, session_id, participants):
+                    await self.send_success_embed(ctx, "Session Ended", "Session ended and stats recorded!")
             else:
                 await self.send_error_embed(ctx, "No Active Session", "No active session to end.")
         except Exception as e:
             self.logger.error(f"Error ending session: {e}")
             await self.send_error_embed(ctx, "End Session Failed", "Failed to end session.")
+
+    async def _send_session_recap(self, ctx: commands.Context, session_id: str, participants: list) -> bool:
+        """Build and send the session recap embed. Returns True if one was sent."""
+        try:
+            session = data_manager.sessions.get(session_id)
+            if session is None:
+                from data_manager import SessionData
+                session = SessionData(session_id)
+
+            tracker = get_match_tracker(self.bot)
+            embed = await tracker.build_session_recap(ctx.guild, participants, session)
+            if embed:
+                await ctx.send(embed=embed)
+                return True
+        except Exception as e:
+            self.logger.error(f"Error building session recap: {e}")
+        return False
     
     async def _end_current_session(self, shooty_context) -> None:
         """Helper method to end the current session"""

--- a/commands/valorant_commands.py
+++ b/commands/valorant_commands.py
@@ -546,7 +546,208 @@ class ValorantCommands(BaseCommandCog):
         except Exception as e:
             self.logger.error(f"Error in shootystatsdetailed command: {e}")
             await self.send_error_embed(ctx, "Error Fetching Detailed Stats", str(e))
-    
+
+    @commands.hybrid_command(
+        name="shootyrank",
+        description="Show current Valorant rank, RR, and last game's RR change"
+    )
+    async def valorant_rank(self, ctx: commands.Context, member: Optional[discord.Member] = None,
+                            account_name: Optional[str] = None) -> None:
+        """Show a player's current competitive rank and RR."""
+        target_user = member or ctx.author
+
+        try:
+            await self.defer_if_slash(ctx)
+
+            accounts = valorant_client.get_all_linked_accounts(target_user.id)
+            if not accounts:
+                await self.send_error_embed(
+                    ctx, "No Linked Accounts",
+                    f"{target_user.display_name} has no linked Valorant accounts"
+                )
+                return
+
+            # Select which account to check
+            selected_account = None
+            if account_name:
+                for account in accounts:
+                    if account['username'].lower() == account_name.lower():
+                        selected_account = account
+                        break
+                if not selected_account:
+                    await self.send_error_embed(
+                        ctx, "Account Not Found",
+                        f"Could not find account '{account_name}' for {target_user.display_name}"
+                    )
+                    return
+            else:
+                selected_account = valorant_client.get_linked_account(target_user.id) or accounts[0]
+
+            mmr = await valorant_client.get_mmr(selected_account['username'], selected_account['tag'])
+            if not mmr or not mmr.get('tier'):
+                await self.send_error_embed(
+                    ctx, "No Rank Data",
+                    "Could not fetch rank. The account may be private, unranked, or the API is unavailable."
+                )
+                return
+
+            rr = mmr.get('rr')
+            change = mmr.get('rr_change')
+            peak = mmr.get('peak')
+            elo = mmr.get('elo')
+
+            lines = [f"{mmr.get('emoji', '')} **{mmr['tier']}**" + (f" — **{rr} RR**" if rr is not None else "")]
+            if change is not None:
+                if change > 0:
+                    lines.append(f"🟢 **+{change} RR** last game")
+                elif change < 0:
+                    lines.append(f"🔴 **{change} RR** last game")
+                else:
+                    lines.append("⚪ **±0 RR** last game")
+            if peak:
+                lines.append(f"🏔️ Peak: **{peak}**")
+            if elo is not None:
+                lines.append(f"📊 Elo: **{elo}**")
+
+            tracker_url = f"https://tracker.gg/valorant/profile/riot/{selected_account['username']}%23{selected_account['tag']}/overview"
+
+            await self.send_embed(
+                ctx,
+                f"{mmr.get('emoji', '')} Rank: {selected_account['username']}#{selected_account['tag']}",
+                "\n".join(lines) + f"\n\n🔗 [View on Tracker.gg]({tracker_url})",
+                color=0xff4655
+            )
+
+        except Exception as e:
+            self.logger.error(f"Error in shootyrank command: {e}")
+            await self.send_error_embed(ctx, "Error Fetching Rank", str(e))
+
+    @commands.hybrid_command(
+        name="shootycompare",
+        description="Compare two players' Valorant stats head-to-head"
+    )
+    async def compare_players(self, ctx: commands.Context, player1: discord.Member,
+                              player2: Optional[discord.Member] = None) -> None:
+        """Head-to-head comparison of two players' competitive stats."""
+        try:
+            await self.defer_if_slash(ctx)
+
+            # Default the second player to the command author
+            if player2 is None:
+                player2 = ctx.author
+
+            if player1.id == player2.id:
+                await self.send_error_embed(
+                    ctx, "Pick Two Players",
+                    "Please choose two different players to compare."
+                )
+                return
+
+            # Gather stats for both players
+            results = []
+            for member in (player1, player2):
+                account = (valorant_client.get_linked_account(member.id)
+                           or next(iter(valorant_client.get_all_linked_accounts(member.id)), None))
+                if not account:
+                    await self.send_error_embed(
+                        ctx, "No Linked Accounts",
+                        f"{member.display_name} has no linked Valorant accounts"
+                    )
+                    return
+
+                matches = await valorant_client.get_match_history(
+                    account['username'], account['tag'], size=20, mode='competitive'
+                )
+                if not matches:
+                    await self.send_error_embed(
+                        ctx, "No Match Data",
+                        f"Could not fetch competitive match history for {member.display_name}."
+                    )
+                    return
+
+                stats = valorant_client.calculate_player_stats(matches, account['puuid'])
+                if not stats or stats.get('total_matches', 0) == 0:
+                    await self.send_error_embed(
+                        ctx, "No Stats Available",
+                        f"No competitive match data found for {member.display_name}."
+                    )
+                    return
+
+                results.append({'member': member, 'account': account, 'stats': stats})
+
+            a, b = results[0], results[1]
+
+            # Comparison rows: (label, value getter, formatter)  — higher is better for all
+            rows = [
+                ("ACS", lambda s: s.get('acs', 0), lambda v: f"{v:.0f}"),
+                ("K/D", lambda s: s.get('kd_ratio', 0), lambda v: f"{v:.2f}"),
+                ("KDA", lambda s: s.get('kda_ratio', 0), lambda v: f"{v:.2f}"),
+                ("KAST", lambda s: s.get('kast_percentage', 0), lambda v: f"{v:.0f}%"),
+                ("ADR", lambda s: s.get('adr', 0), lambda v: f"{v:.0f}"),
+                ("HS%", lambda s: s.get('headshot_percentage', 0), lambda v: f"{v:.1f}%"),
+                ("Win%", lambda s: s.get('win_rate', 0), lambda v: f"{v:.0f}%"),
+                ("FB%", lambda s: s.get('first_blood_rate', 0), lambda v: f"{v:.1f}%"),
+                ("Clutch%", lambda s: s.get('clutch_success_rate', 0), lambda v: f"{v:.0f}%"),
+            ]
+
+            name_a = a['member'].display_name[:9]
+            name_b = b['member'].display_name[:9]
+            header = f"{'Stat':<9}{name_a:<11}{name_b:<11}"
+            table_lines = [header, "─" * len(header)]
+
+            a_wins = b_wins = 0
+            for label, getter, fmt in rows:
+                va = getter(a['stats'])
+                vb = getter(b['stats'])
+                sa, sb = fmt(va), fmt(vb)
+                if va > vb:
+                    sa += " ★"
+                    a_wins += 1
+                elif vb > va:
+                    sb += " ★"
+                    b_wins += 1
+                table_lines.append(f"{label:<9}{sa:<11}{sb:<11}")
+
+            table = "```\n" + "\n".join(table_lines) + "\n```"
+
+            if a_wins > b_wins:
+                verdict = f"🏆 **{a['member'].display_name}** leads {a_wins}–{b_wins} categories"
+                color = 0x00ff66
+            elif b_wins > a_wins:
+                verdict = f"🏆 **{b['member'].display_name}** leads {b_wins}–{a_wins} categories"
+                color = 0x00ff66
+            else:
+                verdict = f"🤝 Dead even — {a_wins}–{b_wins}"
+                color = 0xffaa00
+
+            embed = discord.Embed(
+                title="⚔️ Head-to-Head",
+                description=f"**{a['member'].display_name}** vs **{b['member'].display_name}**\n{table}",
+                color=color
+            )
+            embed.add_field(name="Verdict", value=verdict, inline=False)
+
+            # Current ranks (best-effort)
+            rank_a = await valorant_client.get_mmr(a['account']['username'], a['account']['tag'])
+            rank_b = await valorant_client.get_mmr(b['account']['username'], b['account']['tag'])
+            if (rank_a and rank_a.get('tier')) or (rank_b and rank_b.get('tier')):
+                ra = f"{rank_a.get('emoji', '')} {rank_a['tier']}" if rank_a and rank_a.get('tier') else "Unranked"
+                rb = f"{rank_b.get('emoji', '')} {rank_b['tier']}" if rank_b and rank_b.get('tier') else "Unranked"
+                embed.add_field(
+                    name="Current Rank",
+                    value=f"**{a['member'].display_name}:** {ra}\n**{b['member'].display_name}:** {rb}",
+                    inline=False
+                )
+
+            embed.set_footer(
+                text=f"Last {a['stats']['total_matches']} vs {b['stats']['total_matches']} comp games • ★ = category leader"
+            )
+            await ctx.send(embed=embed)
+
+        except Exception as e:
+            self.logger.error(f"Error in shootycompare command: {e}")
+            await self.send_error_embed(ctx, "Error Comparing Players", str(e))
+
     @commands.hybrid_command(
         name="shootyleaderboard",
         description="Show server leaderboard for Valorant stats (kda, kd, winrate, headshot, acs)"

--- a/match_tracker.py
+++ b/match_tracker.py
@@ -3,7 +3,7 @@ import logging
 import discord
 from datetime import datetime, timezone, timedelta
 from typing import Dict, List, Optional, Any
-from valorant_client import valorant_client
+from valorant_client import valorant_client, get_player_rank, rank_emoji
 import random
 from utils import log_error, format_time_ago, parse_henrik_timestamp
 from context_manager import context_manager
@@ -346,7 +346,9 @@ class MatchTracker:
                 tracked_puuids.add(puuid)
 
             kda = f"{stats.get('kills', 0)}/{stats.get('deaths', 0)}/{stats.get('assists', 0)}"
-            member_list.append(f"• **{member.display_name}**: {kda}")
+            rank = get_player_rank(player_data)
+            rank_str = f" • {rank_emoji(rank)} {rank}" if rank else ""
+            member_list.append(f"• **{member.display_name}**: {kda}{rank_str}")
 
         # Add untracked teammates (players on the same team who aren't linked via shootylink)
         all_players = match.get('players', {}).get('all_players', [])
@@ -362,7 +364,9 @@ class MatchTracker:
                 tag = player.get('tag', '')
                 display_name = f"{name}#{tag}" if tag else name
                 kda = f"{stats.get('kills', 0)}/{stats.get('deaths', 0)}/{stats.get('assists', 0)}"
-                member_list.append(f"• **{display_name}**: {kda}")
+                rank = get_player_rank(player)
+                rank_str = f" • {rank_emoji(rank)} {rank}" if rank else ""
+                member_list.append(f"• **{display_name}**: {kda}{rank_str}")
                 untracked_count += 1
 
         squad_size = len(discord_members) + untracked_count
@@ -374,7 +378,16 @@ class MatchTracker:
             value="\n".join(member_list) if member_list else "No squad members found",
             inline=False
         )
-        
+
+        # Add rank / RR updates for the tracked squad (best-effort)
+        rank_updates = await self._get_squad_rank_updates(discord_members)
+        if rank_updates:
+            embed.add_field(
+                name="📈 Rank Updates",
+                value=rank_updates,
+                inline=False
+            )
+
         # Add enhanced fun highlights
         if fun_stats['highlights']:
             # Limit to top 6 highlights to avoid embed limits
@@ -435,7 +448,224 @@ class MatchTracker:
         
         embed.set_footer(text="Use /shootylink to show up in post-match recaps!")
         return embed
-    
+
+    async def _get_squad_rank_updates(self, discord_members: List[Dict]) -> Optional[str]:
+        """Build a rank/RR update line for each tracked squad member.
+
+        Best-effort: skips members whose MMR can't be fetched (private profile,
+        API down, no key) so the recap still renders without them.
+        """
+        lines = []
+        for dm in discord_members:
+            account = dm.get('account', {}) or {}
+            username = account.get('username')
+            tag = account.get('tag')
+            if not username or not tag:
+                continue
+
+            try:
+                mmr = await valorant_client.get_mmr(username, tag)
+            except Exception as e:
+                log_error(f"fetching rank for {username}#{tag}", e)
+                mmr = None
+
+            if not mmr or not mmr.get('tier'):
+                continue
+
+            member = dm['member']
+            rr = mmr.get('rr')
+            change = mmr.get('rr_change')
+            rr_str = f"{rr} RR" if rr is not None else ""
+
+            if change is None:
+                change_str = ""
+            elif change > 0:
+                change_str = f" (🟢 +{change})"
+            elif change < 0:
+                change_str = f" (🔴 {change})"
+            else:
+                change_str = " (⚪ ±0)"
+
+            sep = " · " if rr_str else ""
+            lines.append(
+                f"• **{member.display_name}**: {mmr.get('emoji', '')} {mmr['tier']}{sep}{rr_str}{change_str}"
+            )
+
+        return "\n".join(lines) if lines else None
+
+    async def build_session_recap(self, guild: discord.Guild, participants: List[discord.Member], session) -> discord.Embed:
+        """Build an end-of-session recap embed.
+
+        Ties the session (``/st`` -> ``/stend``) to the competitive matches the
+        participants actually played during the session window. Always returns a
+        usable embed, degrading gracefully when no Valorant data is available.
+
+        Args:
+            guild: The guild the session ran in.
+            participants: Discord members who were in the stack at end time.
+            session: The ended ``SessionData`` (provides the time window).
+        """
+        # Resolve the session time window
+        start_dt = parse_henrik_timestamp(getattr(session, 'start_time', None))
+        end_dt = parse_henrik_timestamp(getattr(session, 'end_time', None)) or datetime.now(timezone.utc)
+        # Grace before start to catch a match already in progress when /st ran
+        window_start = (start_dt - timedelta(minutes=10)) if start_dt else None
+        window_end = end_dt + timedelta(minutes=5)
+
+        # Collect matches played in-window across all participant accounts
+        matches_by_id: Dict[str, Dict[str, Any]] = {}
+        member_puuids: Dict[str, discord.Member] = {}
+
+        for member in participants:
+            if getattr(member, 'bot', False):
+                continue
+            accounts = valorant_client.get_all_linked_accounts(member.id)
+            for account in accounts:
+                puuid = account.get('puuid')
+                if puuid:
+                    member_puuids[puuid] = member
+                try:
+                    matches = await valorant_client.get_match_history(
+                        account['username'], account['tag'],
+                        size=5, mode='competitive'
+                    )
+                except Exception as e:
+                    log_error(f"fetching session matches for {account.get('username')}", e)
+                    matches = None
+
+                for match in matches or []:
+                    mid = match.get('metadata', {}).get('matchid')
+                    if not mid or mid in matches_by_id:
+                        continue
+                    started = parse_henrik_timestamp(match.get('metadata', {}).get('game_start', ''))
+                    if started is None:
+                        continue
+                    if window_start and started < window_start:
+                        continue
+                    if started > window_end:
+                        continue
+                    matches_by_id[mid] = match
+
+        # Aggregate per-player stats and W/L across in-window matches
+        player_totals: Dict[int, Dict[str, Any]] = {}
+        wins = losses = 0
+        for match in matches_by_id.values():
+            all_players = match.get('players', {}).get('all_players', [])
+            teams = match.get('teams', {})
+            stack_team = None
+            for player in all_players:
+                if player.get('puuid') not in member_puuids:
+                    continue
+                member = member_puuids[player['puuid']]
+                pstats = player.get('stats', {})
+                totals = player_totals.setdefault(member.id, {
+                    'member': member, 'kills': 0, 'deaths': 0, 'assists': 0, 'games': 0
+                })
+                totals['kills'] += pstats.get('kills', 0)
+                totals['deaths'] += pstats.get('deaths', 0)
+                totals['assists'] += pstats.get('assists', 0)
+                totals['games'] += 1
+                if stack_team is None:
+                    stack_team = player.get('team', '').lower()
+            if stack_team and stack_team in teams:
+                if teams[stack_team].get('has_won', False):
+                    wins += 1
+                else:
+                    losses += 1
+
+        # Header
+        games = len(matches_by_id)
+        duration_min = getattr(session, 'duration_minutes', 0) or 0
+        if duration_min >= 60:
+            duration_str = f"{duration_min // 60}h {duration_min % 60}m"
+        else:
+            duration_str = f"{duration_min}m"
+
+        if games == 0:
+            color = 0x808080
+        elif wins > losses:
+            color = 0x00ff66
+        elif losses > wins:
+            color = 0xff4655
+        else:
+            color = 0xffaa00
+
+        desc_parts = [f"🗓️ {len(participants)} player{'s' if len(participants) != 1 else ''}", f"⏱️ {duration_str}"]
+        if games:
+            desc_parts.append(f"🎮 {games} game{'s' if games != 1 else ''} · {wins}W-{losses}L")
+        embed = discord.Embed(
+            title="📊 Session Recap",
+            description=" • ".join(desc_parts),
+            color=color,
+            timestamp=end_dt
+        )
+
+        if games == 0:
+            embed.add_field(
+                name="No tracked games this session",
+                value=(
+                    "No competitive matches were detected for the squad.\n"
+                    "Use `/shootylink <username> <tag>` so your games show up in recaps!"
+                ),
+                inline=False
+            )
+            embed.set_footer(text="GG — see you next session!")
+            return embed
+
+        # Per-player session scoreboard, sorted by KDA, MVP crowned
+        ranked = sorted(
+            player_totals.values(),
+            key=lambda t: (t['kills'] + t['assists']) / max(t['deaths'], 1),
+            reverse=True
+        )
+        scoreboard = []
+        for i, t in enumerate(ranked):
+            kda = (t['kills'] + t['assists']) / max(t['deaths'], 1)
+            crown = "👑 " if i == 0 and len(ranked) > 1 else ""
+            scoreboard.append(
+                f"{crown}**{t['member'].display_name}** — {t['kills']}/{t['deaths']}/{t['assists']} "
+                f"({kda:.2f} KDA, {t['games']}G)"
+            )
+        embed.add_field(
+            name="🏅 Squad Scoreboard",
+            value="\n".join(scoreboard) or "No player data",
+            inline=False
+        )
+
+        if len(ranked) > 1:
+            embed.add_field(
+                name="🌟 MVP of the Night",
+                value=f"**{ranked[0]['member'].display_name}** carried the squad! 🔥",
+                inline=False
+            )
+
+        # End-of-night ranks (best-effort)
+        rank_lines = []
+        for member in participants:
+            account = valorant_client.get_linked_account(member.id)
+            if not account:
+                continue
+            try:
+                mmr = await valorant_client.get_mmr(account['username'], account['tag'])
+            except Exception:
+                mmr = None
+            if mmr and mmr.get('tier'):
+                rr = mmr.get('rr')
+                rr_str = f" · {rr} RR" if rr is not None else ""
+                rank_lines.append(f"• **{member.display_name}**: {mmr.get('emoji', '')} {mmr['tier']}{rr_str}")
+        if rank_lines:
+            embed.add_field(name="📈 Where You Landed", value="\n".join(rank_lines), inline=False)
+
+        # Closing flavor
+        if wins > losses:
+            flavor = "🔥 Winning night — GG WP!"
+        elif losses > wins:
+            flavor = "😅 Rough night. Run it back next time! 💪"
+        else:
+            flavor = "⚖️ Even night — the grind continues."
+        embed.set_footer(text=flavor)
+        return embed
+
     def _calculate_fun_match_stats(self, match_data: dict, discord_members: List[Dict]) -> Dict:
         """Calculate fun and interesting match statistics"""
         stats = {

--- a/tests/unit/commands/test_valorant_commands.py
+++ b/tests/unit/commands/test_valorant_commands.py
@@ -212,5 +212,74 @@ class TestValorantCommands(unittest.IsolatedAsyncioTestCase):
         mock_remove_account.assert_any_call(1111, 'Player2', 'EU1')
         mock_data_manager.save_user.assert_called_once_with(1111)
 
+    @patch('commands.valorant_commands.valorant_client')
+    async def test_shootyrank_success(self, mock_valorant_client):
+        """shootyrank should display the player's current rank and RR."""
+        mock_valorant_client.get_all_linked_accounts.return_value = [
+            {'username': 'TestPlayer', 'tag': 'NA1', 'puuid': 'puuid-1'}
+        ]
+        mock_valorant_client.get_linked_account.return_value = {
+            'username': 'TestPlayer', 'tag': 'NA1', 'puuid': 'puuid-1'
+        }
+        mock_valorant_client.get_mmr = AsyncMock(return_value={
+            'tier': 'Diamond 1', 'rr': 45, 'rr_change': 18, 'elo': 1845,
+            'peak': 'Diamond 2', 'emoji': '💎',
+        })
+
+        await self.cog.valorant_rank.callback(self.cog, self.ctx)
+
+        self.cog.send_embed.assert_awaited()
+        # Description should mention rank, RR and the positive RR change
+        args, kwargs = self.cog.send_embed.call_args
+        body = " ".join(str(a) for a in args) + " ".join(f"{v}" for v in kwargs.values())
+        self.assertIn('Diamond 1', body)
+        self.assertIn('+18', body)
+
+    @patch('commands.valorant_commands.valorant_client')
+    async def test_shootyrank_no_accounts(self, mock_valorant_client):
+        """shootyrank should error gracefully when no accounts are linked."""
+        mock_valorant_client.get_all_linked_accounts.return_value = []
+
+        await self.cog.valorant_rank.callback(self.cog, self.ctx)
+
+        self.cog.send_error_embed.assert_awaited()
+
+    @patch('commands.valorant_commands.valorant_client')
+    async def test_shootycompare_picks_winner(self, mock_valorant_client):
+        """shootycompare should fetch both players and crown the stronger one."""
+        player1 = MagicMock(spec=discord.Member)
+        player1.id = 1
+        player1.display_name = "Alice"
+        # player2 defaults to ctx.author (id 123456789)
+
+        accounts = {
+            1: {'username': 'Alice', 'tag': 'NA1', 'puuid': 'pa'},
+            123456789: {'username': 'TestUser', 'tag': 'NA1', 'puuid': 'pb'},
+        }
+        stats = {
+            'pa': {'total_matches': 20, 'acs': 280, 'kd_ratio': 1.4, 'kda_ratio': 1.8,
+                   'kast_percentage': 75, 'adr': 160, 'headshot_percentage': 28,
+                   'win_rate': 60, 'first_blood_rate': 12, 'clutch_success_rate': 55},
+            'pb': {'total_matches': 18, 'acs': 200, 'kd_ratio': 0.9, 'kda_ratio': 1.2,
+                   'kast_percentage': 65, 'adr': 130, 'headshot_percentage': 20,
+                   'win_rate': 45, 'first_blood_rate': 8, 'clutch_success_rate': 40},
+        }
+        mock_valorant_client.get_linked_account.side_effect = lambda uid: accounts.get(uid)
+        mock_valorant_client.get_all_linked_accounts.side_effect = lambda uid: [accounts[uid]] if uid in accounts else []
+        mock_valorant_client.get_match_history = AsyncMock(
+            side_effect=lambda u, t, **kw: [{'puuid': 'pa' if u == 'Alice' else 'pb'}]
+        )
+        mock_valorant_client.calculate_player_stats.side_effect = (
+            lambda matches, puuid, **kw: stats[matches[0]['puuid']]
+        )
+        mock_valorant_client.get_mmr = AsyncMock(return_value=None)
+
+        await self.cog.compare_players.callback(self.cog, self.ctx, player1)
+
+        self.ctx.send.assert_awaited()
+        embed = self.ctx.send.call_args.kwargs['embed']
+        verdict = next(f for f in embed.fields if f.name == 'Verdict')
+        self.assertIn('Alice', verdict.value)
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/unit/test_rank_features.py
+++ b/tests/unit/test_rank_features.py
@@ -1,0 +1,278 @@
+"""Tests for rank/RR integration, head-to-head comparison, and session recap."""
+
+import pytest
+from unittest.mock import MagicMock, AsyncMock, patch
+import discord
+
+from valorant_client import ValorantClient, tier_name, rank_emoji, get_player_rank
+from api_clients import APIResponse
+from match_tracker import MatchTracker
+
+
+# ---------------------------------------------------------------------------
+# Rank helper functions
+# ---------------------------------------------------------------------------
+
+def test_tier_name_maps_known_tiers():
+    assert tier_name(0) == "Unrated"
+    assert tier_name(18) == "Diamond 1"
+    assert tier_name(27) == "Radiant"
+
+
+def test_tier_name_handles_bad_input():
+    assert tier_name(None) == "Unrated"
+    assert tier_name("not-a-number") == "Unrated"
+    assert tier_name(999) == "Unrated"
+
+
+def test_rank_emoji_by_family():
+    assert rank_emoji("Diamond 1") == "💎"
+    assert rank_emoji("Radiant") == "✨"
+    assert rank_emoji(None) == "❔"
+
+
+def test_get_player_rank_prefers_patched_string():
+    assert get_player_rank({'currenttier_patched': 'Ascendant 2', 'currenttier': 22}) == "Ascendant 2"
+
+
+def test_get_player_rank_falls_back_to_numeric():
+    assert get_player_rank({'currenttier': 21}) == "Ascendant 1"
+
+
+def test_get_player_rank_returns_none_when_absent():
+    assert get_player_rank({'stats': {}}) is None
+
+
+# ---------------------------------------------------------------------------
+# get_mmr
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_get_mmr_parses_response():
+    client = ValorantClient()
+    mmr_data = {
+        'current_data': {
+            'currenttier': 18,
+            'currenttierpatched': 'Diamond 1',
+            'ranking_in_tier': 45,
+            'mmr_change_to_last_game': 18,
+            'elo': 1845,
+        },
+        'highest_rank': {'patched_tier': 'Diamond 2'},
+    }
+    client.get = AsyncMock(return_value=APIResponse(data={'data': mmr_data}, status_code=200))
+
+    result = await client.get_mmr('user', 'tag')
+
+    assert result['tier'] == 'Diamond 1'
+    assert result['rr'] == 45
+    assert result['rr_change'] == 18
+    assert result['elo'] == 1845
+    assert result['peak'] == 'Diamond 2'
+    assert result['emoji'] == '💎'
+    # base_url must be restored after the v2 swap
+    assert client.base_url == "https://api.henrikdev.xyz/valorant/v1"
+
+
+@pytest.mark.asyncio
+async def test_get_mmr_returns_none_on_failure():
+    client = ValorantClient()
+    client.get = AsyncMock(return_value=APIResponse(data={}, status_code=404))
+    assert await client.get_mmr('user', 'tag') is None
+
+
+@pytest.mark.asyncio
+async def test_get_mmr_returns_none_on_exception():
+    client = ValorantClient()
+    client.get = AsyncMock(side_effect=Exception("boom"))
+    assert await client.get_mmr('user', 'tag') is None
+    # base_url still restored even when the call blows up
+    assert client.base_url == "https://api.henrikdev.xyz/valorant/v1"
+
+
+# ---------------------------------------------------------------------------
+# Rank shown in the match recap embed
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_match_embed_shows_player_rank(discord_member_factory):
+    bot = MagicMock(spec=discord.Client)
+    tracker = MatchTracker(bot)
+
+    match = {
+        'metadata': {
+            'map': 'Ascent', 'rounds_played': 13, 'game_length': 1800,
+            'game_start': '2024-01-01T00:00:00Z', 'matchid': 'abc123',
+        },
+        'teams': {'red': {'has_won': True, 'rounds_won': 13},
+                  'blue': {'has_won': False, 'rounds_won': 8}},
+        'players': {'all_players': [
+            {'puuid': 'p1', 'name': 'Tracked', 'tag': 'NA1', 'team': 'Red',
+             'currenttier_patched': 'Diamond 1', 'currenttier': 18,
+             'stats': {'kills': 20, 'deaths': 10, 'assists': 5}},
+        ]},
+    }
+    member = discord_member_factory(user_id=1, name='TrackedName')
+    discord_members = [{'member': member, 'account': {'puuid': 'p1'},
+                        'player_data': match['players']['all_players'][0]}]
+
+    with patch('match_tracker.format_time_ago', return_value='just now'), \
+         patch.object(tracker, '_calculate_fun_match_stats',
+                      return_value={'highlights': [], 'top_performers': {}, 'funny_stats': {}}), \
+         patch.object(tracker, '_get_squad_rank_updates', AsyncMock(return_value=None)):
+        embed = await tracker._create_match_embed(match, discord_members)
+
+    squad_field = next(f for f in embed.fields if 'Squad' in f.name)
+    assert 'Diamond 1' in squad_field.value
+
+
+# ---------------------------------------------------------------------------
+# _get_squad_rank_updates
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_squad_rank_updates_formats_rr_change(discord_member_factory):
+    bot = MagicMock(spec=discord.Client)
+    tracker = MatchTracker(bot)
+    member = discord_member_factory(user_id=1, name='Player1')
+    discord_members = [{'member': member,
+                        'account': {'puuid': 'p1', 'username': 'Player1', 'tag': 'NA1'}}]
+
+    fake_client = MagicMock()
+    fake_client.get_mmr = AsyncMock(return_value={
+        'tier': 'Diamond 1', 'rr': 45, 'rr_change': 18, 'emoji': '💎', 'peak': 'Diamond 2',
+    })
+    with patch('match_tracker.valorant_client', fake_client):
+        result = await tracker._get_squad_rank_updates(discord_members)
+
+    assert 'Player1' in result
+    assert 'Diamond 1' in result
+    assert '45 RR' in result
+    assert '+18' in result
+
+
+@pytest.mark.asyncio
+async def test_squad_rank_updates_skips_accounts_without_credentials(discord_member_factory):
+    bot = MagicMock(spec=discord.Client)
+    tracker = MatchTracker(bot)
+    member = discord_member_factory(user_id=1, name='Player1')
+    # No username/tag -> should not trigger an API call and returns None
+    discord_members = [{'member': member, 'account': {'puuid': 'p1'}}]
+
+    fake_client = MagicMock()
+    fake_client.get_mmr = AsyncMock()
+    with patch('match_tracker.valorant_client', fake_client):
+        result = await tracker._get_squad_rank_updates(discord_members)
+
+    assert result is None
+    fake_client.get_mmr.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# build_session_recap
+# ---------------------------------------------------------------------------
+
+def _make_session(start, end, duration):
+    session = MagicMock()
+    session.start_time = start
+    session.end_time = end
+    session.duration_minutes = duration
+    return session
+
+
+@pytest.mark.asyncio
+async def test_session_recap_with_games(discord_member_factory):
+    bot = MagicMock(spec=discord.Client)
+    tracker = MatchTracker(bot)
+
+    m1 = discord_member_factory(user_id=1, name='Alice')
+    m2 = discord_member_factory(user_id=2, name='Bob')
+    m1.bot = False
+    m2.bot = False
+    guild = MagicMock(spec=discord.Guild)
+
+    match = {
+        'metadata': {'matchid': 'm1', 'game_start': '2024-01-01T00:30:00Z'},
+        'teams': {'red': {'has_won': True}, 'blue': {'has_won': False}},
+        'players': {'all_players': [
+            {'puuid': 'pa', 'team': 'Red', 'stats': {'kills': 25, 'deaths': 10, 'assists': 5}},
+            {'puuid': 'pb', 'team': 'Red', 'stats': {'kills': 12, 'deaths': 15, 'assists': 8}},
+        ]},
+    }
+
+    fake_client = MagicMock()
+    accounts = {1: [{'username': 'Alice', 'tag': 'NA1', 'puuid': 'pa'}],
+                2: [{'username': 'Bob', 'tag': 'NA1', 'puuid': 'pb'}]}
+    fake_client.get_all_linked_accounts.side_effect = lambda uid: accounts.get(uid, [])
+    fake_client.get_linked_account.side_effect = lambda uid: accounts.get(uid, [None])[0]
+    fake_client.get_match_history = AsyncMock(return_value=[match])
+    fake_client.get_mmr = AsyncMock(return_value=None)
+
+    session = _make_session('2024-01-01T00:00:00+00:00', '2024-01-01T02:00:00+00:00', 120)
+
+    with patch('match_tracker.valorant_client', fake_client):
+        embed = await tracker.build_session_recap(guild, [m1, m2], session)
+
+    assert embed.title == "📊 Session Recap"
+    assert '1 game' in embed.description
+    assert '1W-0L' in embed.description
+    scoreboard = next(f for f in embed.fields if 'Scoreboard' in f.name)
+    # Alice has the better KDA, so she is crowned MVP / listed first
+    assert '👑' in scoreboard.value
+    assert 'Alice' in scoreboard.value
+    assert 'Bob' in scoreboard.value
+    mvp = next(f for f in embed.fields if 'MVP' in f.name)
+    assert 'Alice' in mvp.value
+
+
+@pytest.mark.asyncio
+async def test_session_recap_no_games(discord_member_factory):
+    bot = MagicMock(spec=discord.Client)
+    tracker = MatchTracker(bot)
+    m1 = discord_member_factory(user_id=1, name='Alice')
+    m1.bot = False
+    guild = MagicMock(spec=discord.Guild)
+
+    fake_client = MagicMock()
+    fake_client.get_all_linked_accounts.return_value = []
+    fake_client.get_linked_account.return_value = None
+    fake_client.get_match_history = AsyncMock(return_value=[])
+    fake_client.get_mmr = AsyncMock(return_value=None)
+
+    session = _make_session('2024-01-01T00:00:00+00:00', '2024-01-01T00:45:00+00:00', 45)
+
+    with patch('match_tracker.valorant_client', fake_client):
+        embed = await tracker.build_session_recap(guild, [m1], session)
+
+    assert embed.title == "📊 Session Recap"
+    assert any('No tracked games' in f.name for f in embed.fields)
+
+
+@pytest.mark.asyncio
+async def test_session_recap_excludes_out_of_window_matches(discord_member_factory):
+    bot = MagicMock(spec=discord.Client)
+    tracker = MatchTracker(bot)
+    m1 = discord_member_factory(user_id=1, name='Alice')
+    m1.bot = False
+    guild = MagicMock(spec=discord.Guild)
+
+    # Match started long before the session window
+    old_match = {
+        'metadata': {'matchid': 'old', 'game_start': '2023-12-01T00:00:00Z'},
+        'teams': {'red': {'has_won': True}, 'blue': {'has_won': False}},
+        'players': {'all_players': [
+            {'puuid': 'pa', 'team': 'Red', 'stats': {'kills': 25, 'deaths': 10, 'assists': 5}},
+        ]},
+    }
+    fake_client = MagicMock()
+    fake_client.get_all_linked_accounts.return_value = [{'username': 'Alice', 'tag': 'NA1', 'puuid': 'pa'}]
+    fake_client.get_linked_account.return_value = {'username': 'Alice', 'tag': 'NA1', 'puuid': 'pa'}
+    fake_client.get_match_history = AsyncMock(return_value=[old_match])
+    fake_client.get_mmr = AsyncMock(return_value=None)
+
+    session = _make_session('2024-01-01T00:00:00+00:00', '2024-01-01T02:00:00+00:00', 120)
+
+    with patch('match_tracker.valorant_client', fake_client):
+        embed = await tracker.build_session_recap(guild, [m1], session)
+
+    assert any('No tracked games' in f.name for f in embed.fields)

--- a/valorant_client.py
+++ b/valorant_client.py
@@ -7,6 +7,61 @@ from utils import log_error
 from api_clients import BaseAPIClient, RateLimitInfo, APIResponse
 from database import database_manager
 
+# Henrik/Valorant competitive tier numbers -> human readable names.
+# Tiers 1 and 2 are unused by Riot. 0 == Unrated.
+RANK_TIERS = {
+    0: "Unrated",
+    3: "Iron 1", 4: "Iron 2", 5: "Iron 3",
+    6: "Bronze 1", 7: "Bronze 2", 8: "Bronze 3",
+    9: "Silver 1", 10: "Silver 2", 11: "Silver 3",
+    12: "Gold 1", 13: "Gold 2", 14: "Gold 3",
+    15: "Platinum 1", 16: "Platinum 2", 17: "Platinum 3",
+    18: "Diamond 1", 19: "Diamond 2", 20: "Diamond 3",
+    21: "Ascendant 1", 22: "Ascendant 2", 23: "Ascendant 3",
+    24: "Immortal 1", 25: "Immortal 2", 26: "Immortal 3",
+    27: "Radiant",
+}
+
+# Emoji flair per rank family (matched on the patched tier name).
+RANK_EMOJIS = {
+    "Unrated": "❔", "Iron": "🟤", "Bronze": "🥉", "Silver": "⚪",
+    "Gold": "🥇", "Platinum": "💧", "Diamond": "💎", "Ascendant": "🟢",
+    "Immortal": "🔴", "Radiant": "✨",
+}
+
+
+def tier_name(currenttier: Any) -> str:
+    """Resolve a numeric competitive tier to its patched name."""
+    try:
+        return RANK_TIERS.get(int(currenttier), "Unrated")
+    except (TypeError, ValueError):
+        return "Unrated"
+
+
+def rank_emoji(patched_tier: Optional[str]) -> str:
+    """Get an emoji for a patched tier name (e.g. 'Diamond 1' -> 💎)."""
+    if not patched_tier:
+        return "❔"
+    family = patched_tier.split(" ")[0]
+    return RANK_EMOJIS.get(family, "🎖️")
+
+
+def get_player_rank(player_data: Dict[str, Any]) -> Optional[str]:
+    """Extract a patched rank name from a match player object.
+
+    Henrik match data exposes ``currenttier`` (int) and sometimes
+    ``currenttier_patched`` (str). Prefer the patched string, fall back to the
+    numeric mapping.
+    """
+    patched = player_data.get('currenttier_patched')
+    if patched:
+        return patched
+    currenttier = player_data.get('currenttier')
+    if currenttier is not None:
+        return tier_name(currenttier)
+    return None
+
+
 class ValorantClient(BaseAPIClient):
     """Client for interacting with Henrik's Valorant API"""
     
@@ -253,7 +308,64 @@ class ValorantClient(BaseAPIClient):
         except Exception as e:
             log_error("fetching match history", e)
             return None
-    
+
+    async def get_mmr(self, username: str, tag: str, region: str = 'na',
+                      force_refresh: bool = False) -> Optional[Dict[str, Any]]:
+        """Fetch a player's current rank / RR info from Henrik's MMR endpoint.
+
+        Returns a normalized dict::
+
+            {
+                'tier': 'Diamond 1',          # patched current tier
+                'rr': 45,                     # ranking_in_tier (0-100)
+                'rr_change': 18,              # mmr_change_to_last_game (+/-)
+                'elo': 1845,
+                'peak': 'Diamond 2',          # highest rank achieved (best-effort)
+                'emoji': '💎',
+            }
+
+        Returns ``None`` if the account is private, not found, or the API is
+        unavailable. This is intentionally best-effort so callers can degrade
+        gracefully.
+        """
+        try:
+            # MMR lives on the v2 API; swap the base URL like get_match_history.
+            original_base_url = self.base_url
+            self.base_url = "https://api.henrikdev.xyz/valorant/v2"
+            try:
+                response = await self.get(
+                    f'mmr/{region}/{username}/{tag}',
+                    use_cache=not force_refresh,
+                    cache_ttl=120  # Cache rank for 2 minutes
+                )
+
+                if not response.success:
+                    logging.warning(f"MMR fetch failed for {username}#{tag}: {response.status_code}")
+                    return None
+
+                data = response.data['data'] if 'data' in response.data else response.data
+                if not data:
+                    return None
+
+                current = data.get('current_data', {}) or {}
+                highest = data.get('highest_rank', {}) or {}
+
+                patched = current.get('currenttierpatched') or tier_name(current.get('currenttier'))
+                return {
+                    'tier': patched,
+                    'rr': current.get('ranking_in_tier'),
+                    'rr_change': current.get('mmr_change_to_last_game'),
+                    'elo': current.get('elo'),
+                    'peak': highest.get('patched_tier'),
+                    'emoji': rank_emoji(patched),
+                }
+            finally:
+                self.base_url = original_base_url
+
+        except Exception as e:
+            log_error(f"fetching MMR for {username}#{tag}", e)
+            return None
+
     def calculate_player_stats(self, matches: List[Dict[str, Any]], player_puuid: str, competitive_only: bool = True) -> Dict[str, Any]:
         """Calculate comprehensive player statistics from match history using tournament-grade accuracy
         


### PR DESCRIPTION
Ship three post-game UX features that build on existing stat infrastructure:

1. Rank / RR integration (valorant_client.get_mmr)
   - New Henrik v2 MMR fetch returning current tier, RR, last-game RR
     change, elo, and peak rank, with tier-number-to-name mapping and
     rank emoji helpers (tier_name/rank_emoji/get_player_rank).
   - Post-match recaps now show each squad member's rank inline plus a
     "Rank Updates" field with +/- RR change (best-effort, degrades
     gracefully when MMR is unavailable).
   - New /shootyrank command for on-demand rank, RR, peak, and elo.

2. /shootycompare head-to-head
   - Side-by-side comparison of two players across ACS, K/D, KDA, KAST,
     ADR, HS%, win rate, first-blood rate, and clutch %, with a
     category-leader verdict and current ranks. Reuses
     calculate_player_stats; defaults the second player to the caller.

3. Session recap at /stend
   - MatchTracker.build_session_recap ties a session to the competitive
     matches played during its window: games count, W-L, per-player
     scoreboard, MVP of the night, and end-of-night ranks. Falls back to
     a friendly "no tracked games" card when no data is available.

Help text updated for the new commands. Adds unit tests covering rank
helpers, get_mmr parsing/failure paths, squad rank updates, session
recap (games / no-games / out-of-window), and the new commands.

https://claude.ai/code/session_01Mx37qcpPdSxKN3RPz5236C