### PR TITLE
Auto-add session initiator to solo queue on session start

### DIFF
--- a/commands/session_commands.py
+++ b/commands/session_commands.py
@@ -53,6 +53,9 @@ class SessionCommands(BaseCommandCog):
             # Reset users
             shooty_context.reset_users()
 
+            # Auto-add the session initiator to the solo queue
+            shooty_context.add_soloq_user(ctx.author)
+
             # Update bot status after resetting users
             await self.bot.update_status_with_queue_count()
 


### PR DESCRIPTION
## Summary
When a user initiates a new gaming session, they are now automatically added to the solo queue instead of requiring a manual action.

## Changes
- Auto-add the session initiator (`ctx.author`) to the solo queue when `start_session()` is called
- This occurs after user reset but before the bot status update, ensuring the initiator is immediately available in the queue

## Implementation Details
- Uses the existing `shooty_context.add_soloq_user()` method to add the session initiator
- Maintains the existing session initialization flow and status update sequence
- Improves user experience by reducing friction when starting a new session

https://claude.ai/code/session_014UnPyodANtafSdeEavWS5M