### PR TITLE
Add weapon leaderboard and concurrent stats gathering

### DIFF
--- a/commands/valorant_commands.py
+++ b/commands/valorant_commands.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 from typing import List, Optional
 import discord
@@ -759,6 +760,45 @@ class ValorantCommands(BaseCommandCog):
             self.logger.error(f"Error in shootycompare command: {e}")
             await self.send_error_embed(ctx, "Error Comparing Players", str(e))
 
+    # Cap concurrent Henrik API requests so leaderboards don't trip rate limits
+    _LEADERBOARD_CONCURRENCY = 5
+
+    async def _gather_member_stats(self, guild: discord.Guild, size: int = 10) -> List[dict]:
+        """Fetch Valorant stats for every member with a linked account, concurrently.
+
+        Results are cached at the client/DB layer, so warm runs make no API calls;
+        cold runs are bounded by a semaphore to respect Henrik API rate limits.
+
+        Returns a list of dicts: {'member', 'account', 'stats'}.
+        """
+        semaphore = asyncio.Semaphore(self._LEADERBOARD_CONCURRENCY)
+
+        async def fetch(member: discord.Member, account: dict) -> Optional[dict]:
+            async with semaphore:
+                try:
+                    matches = await valorant_client.get_match_history(
+                        account['username'], account['tag'], size=size
+                    )
+                    if not matches:
+                        return None
+                    stats = valorant_client.calculate_player_stats(matches, account['puuid'])
+                    return {'member': member, 'account': account, 'stats': stats}
+                except Exception as e:
+                    self.logger.warning(f"Error getting stats for {member.display_name}: {e}")
+                    return None
+
+        tasks = []
+        for member in guild.members:
+            if member.bot:
+                continue
+            account = valorant_client.get_linked_account(member.id)
+            if not account:
+                continue
+            tasks.append(fetch(member, account))
+
+        results = await asyncio.gather(*tasks)
+        return [r for r in results if r is not None]
+
     @commands.hybrid_command(
         name="shootyleaderboard",
         description="Show server leaderboard for Valorant stats (kda, kd, winrate, headshot, acs)"
@@ -777,41 +817,13 @@ class ValorantCommands(BaseCommandCog):
             return
         
         try:
-            # Collect stats for all members with linked accounts
-            member_stats = []
-            
-            for member in ctx.guild.members:
-                if member.bot:
-                    continue
-                    
-                accounts = valorant_client.get_all_linked_accounts(member.id)
-                if not accounts:
-                    continue
-                
-                primary_account = valorant_client.get_linked_account(member.id)
-                if not primary_account:
-                    continue
-                
-                try:
-                    # Get recent matches for stats calculation
-                    matches = await valorant_client.get_match_history(
-                        primary_account['username'],
-                        primary_account['tag'],
-                        size=10  # Use fewer matches for leaderboard to be faster
-                    )
-                    
-                    if matches:
-                        stats = valorant_client.calculate_player_stats(matches, primary_account['puuid'])
-                        if stats.get('total_matches', 0) >= 3:  # Minimum 3 matches for leaderboard
-                            member_stats.append({
-                                'member': member,
-                                'account': primary_account,
-                                'stats': stats
-                            })
-                except Exception as e:
-                    self.logger.warning(f"Error getting stats for {member.display_name}: {e}")
-                    continue
-            
+            # Collect stats for all members with linked accounts (concurrently)
+            all_member_stats = await self._gather_member_stats(ctx.guild, size=10)
+            # Minimum 3 matches for leaderboard
+            member_stats = [
+                m for m in all_member_stats if m['stats'].get('total_matches', 0) >= 3
+            ]
+
             if not member_stats:
                 await self.send_embed(
                     ctx,
@@ -996,44 +1008,26 @@ class ValorantCommands(BaseCommandCog):
             return
 
         try:
-            # Collect per-weapon kills for all members with linked accounts
+            # Collect stats for all members with linked accounts (concurrently),
+            # then tally kills with the requested weapon
+            all_member_stats = await self._gather_member_stats(ctx.guild, size=10)
+
             member_stats = []
+            for entry in all_member_stats:
+                stats = entry['stats']
+                # Match weapon names case-insensitively against the player's tally
+                weapon_kills = {
+                    name.lower(): count
+                    for name, count in stats.get('weapon_kills', {}).items()
+                }
+                kills = weapon_kills.get(canonical_weapon.lower(), 0)
 
-            for member in ctx.guild.members:
-                if member.bot:
-                    continue
-
-                primary_account = valorant_client.get_linked_account(member.id)
-                if not primary_account:
-                    continue
-
-                try:
-                    matches = await valorant_client.get_match_history(
-                        primary_account['username'],
-                        primary_account['tag'],
-                        size=10  # Use fewer matches for leaderboard to be faster
-                    )
-
-                    if not matches:
-                        continue
-
-                    stats = valorant_client.calculate_player_stats(matches, primary_account['puuid'])
-                    # Match weapon names case-insensitively against the player's tally
-                    weapon_kills = {
-                        name.lower(): count
-                        for name, count in stats.get('weapon_kills', {}).items()
-                    }
-                    kills = weapon_kills.get(canonical_weapon.lower(), 0)
-
-                    if kills > 0:
-                        member_stats.append({
-                            'member': member,
-                            'kills': kills,
-                            'matches': stats.get('total_matches', 0)
-                        })
-                except Exception as e:
-                    self.logger.warning(f"Error getting weapon stats for {member.display_name}: {e}")
-                    continue
+                if kills > 0:
+                    member_stats.append({
+                        'member': entry['member'],
+                        'kills': kills,
+                        'matches': stats.get('total_matches', 0)
+                    })
 
             if not member_stats:
                 await self.send_embed(

--- a/commands/valorant_commands.py
+++ b/commands/valorant_commands.py
@@ -1,12 +1,23 @@
 import logging
-from typing import Optional
+from typing import List, Optional
 import discord
+from discord import app_commands
 from discord.ext import commands
 from base_commands import BaseCommandCog
 from valorant_client import valorant_client
 from data_manager import data_manager
 from datetime import datetime, timezone
 from match_tracker import get_match_tracker
+from config import VALORANT_WEAPON_LIST
+
+
+async def weapon_autocomplete(
+    interaction: discord.Interaction, current: str
+) -> List[app_commands.Choice[str]]:
+    """Autocomplete handler for weapon names in the weapon leaderboard command."""
+    current = (current or "").lower()
+    matches = [w for w in VALORANT_WEAPON_LIST if current in w.lower()]
+    return [app_commands.Choice(name=weapon, value=weapon) for weapon in matches[:25]]
 
 class ValorantCommands(BaseCommandCog):
     """Commands for Valorant integration and account management"""
@@ -959,6 +970,128 @@ class ValorantCommands(BaseCommandCog):
                 "Sorry, there was an error generating the leaderboard. Please try again later."
             )
     
+    @commands.hybrid_command(
+        name="shootyweaponstats",
+        description="Server leaderboard of kills with a specific weapon (e.g., /shootyweaponstats Vandal)"
+    )
+    @app_commands.describe(weapon="The Valorant weapon to rank players by (start typing for suggestions)")
+    @app_commands.autocomplete(weapon=weapon_autocomplete)
+    async def weapon_leaderboard(self, ctx: commands.Context, *, weapon: str) -> None:
+        """Show a server leaderboard ranking players by kills with a given weapon."""
+        await self.defer_if_slash(ctx)
+
+        # Resolve the requested weapon to a canonical name (case-insensitive)
+        requested = weapon.strip()
+        canonical_weapon = next(
+            (w for w in VALORANT_WEAPON_LIST if w.lower() == requested.lower()),
+            None
+        )
+        if not canonical_weapon:
+            await self.send_error_embed(
+                ctx,
+                "Unknown Weapon",
+                f"'{requested}' isn't a recognized weapon.\n"
+                f"Valid weapons: {', '.join(VALORANT_WEAPON_LIST)}"
+            )
+            return
+
+        try:
+            # Collect per-weapon kills for all members with linked accounts
+            member_stats = []
+
+            for member in ctx.guild.members:
+                if member.bot:
+                    continue
+
+                primary_account = valorant_client.get_linked_account(member.id)
+                if not primary_account:
+                    continue
+
+                try:
+                    matches = await valorant_client.get_match_history(
+                        primary_account['username'],
+                        primary_account['tag'],
+                        size=10  # Use fewer matches for leaderboard to be faster
+                    )
+
+                    if not matches:
+                        continue
+
+                    stats = valorant_client.calculate_player_stats(matches, primary_account['puuid'])
+                    # Match weapon names case-insensitively against the player's tally
+                    weapon_kills = {
+                        name.lower(): count
+                        for name, count in stats.get('weapon_kills', {}).items()
+                    }
+                    kills = weapon_kills.get(canonical_weapon.lower(), 0)
+
+                    if kills > 0:
+                        member_stats.append({
+                            'member': member,
+                            'kills': kills,
+                            'matches': stats.get('total_matches', 0)
+                        })
+                except Exception as e:
+                    self.logger.warning(f"Error getting weapon stats for {member.display_name}: {e}")
+                    continue
+
+            if not member_stats:
+                await self.send_embed(
+                    ctx,
+                    f"🔫 Server {canonical_weapon} Leaderboard",
+                    f"No recent kills with the **{canonical_weapon}** found among linked players.",
+                    color=0x808080
+                )
+                return
+
+            # Sort by weapon kills (descending)
+            member_stats.sort(key=lambda x: x['kills'], reverse=True)
+
+            embed = discord.Embed(
+                title=f"🔫 Server Leaderboard: {canonical_weapon} Kills",
+                description=f"Top {min(10, len(member_stats))} players by **{canonical_weapon}** kills "
+                            f"(based on each player's recent competitive matches)",
+                color=0xff4655
+            )
+
+            leaderboard_text = []
+            for i, player_data in enumerate(member_stats[:10]):
+                member = player_data['member']
+                kills = player_data['kills']
+                matches = player_data['matches']
+                rank_emoji = "🥇" if i == 0 else "🥈" if i == 1 else "🥉" if i == 2 else f"{i+1}."
+                leaderboard_text.append(
+                    f"{rank_emoji} **{member.display_name}** - {kills} kills ({matches}G)"
+                )
+
+            embed.add_field(
+                name="🎯 Top Fraggers",
+                value="\n".join(leaderboard_text),
+                inline=False
+            )
+
+            total_weapon_kills = sum(p['kills'] for p in member_stats)
+            embed.add_field(
+                name="📊 Server Stats",
+                value=f"**Players:** {len(member_stats)}\n**Total {canonical_weapon} Kills:** {total_weapon_kills}",
+                inline=True
+            )
+
+            embed.set_footer(
+                text="🔄 Try other weapons with /shootyweaponstats <weapon> • "
+                     "Stats reflect each player's recent matches"
+            )
+
+            await ctx.send(embed=embed)
+
+        except Exception as e:
+            self.logger.error(f"Error in weapon leaderboard command: {e}")
+            await self.send_error_embed(
+                ctx,
+                "Weapon Leaderboard Error",
+                "Sorry, there was an error generating the weapon leaderboard. Please try again later."
+            )
+
     @commands.hybrid_command(
         name="shootyhistory",
         description="Show session history for this channel"

--- a/config.py
+++ b/config.py
@@ -50,6 +50,21 @@ CUSTOM_EMOJI = {
     "PARTY_EMPTY": "<:viper:725612569716326422>"
 }
 
+# Valorant Weapons (grouped by category)
+# Display names match the Henrik API kill_event weapon names (valorant-api.com display names)
+VALORANT_WEAPONS = {
+    "Sidearms": ["Classic", "Shorty", "Frenzy", "Ghost", "Sheriff"],
+    "SMGs": ["Stinger", "Spectre"],
+    "Shotguns": ["Bucky", "Judge"],
+    "Rifles": ["Bulldog", "Guardian", "Phantom", "Vandal"],
+    "Snipers": ["Marshal", "Outlaw", "Operator"],
+    "Machine Guns": ["Ares", "Odin"],
+    "Melee": ["Melee"],
+}
+
+# Flat, ordered list of all weapon names for quick lookups / autocomplete
+VALORANT_WEAPON_LIST = [weapon for weapons in VALORANT_WEAPONS.values() for weapon in weapons]
+
 # Message Templates
 MESSAGES = {
     "NO_ROLE": "First set the role for the bot to ping with ```$stsr <Role>```",

--- a/tests/unit/commands/test_valorant_commands.py
+++ b/tests/unit/commands/test_valorant_commands.py
@@ -289,6 +289,34 @@ class TestValorantCommands(unittest.IsolatedAsyncioTestCase):
         return member
 
     @patch('commands.valorant_commands.valorant_client')
+    async def test_gather_member_stats_skips_bots_and_unlinked(self, mock_valorant_client):
+        """The shared helper fetches only linked, non-bot members."""
+        alice = self._make_member(1, 'Alice')
+        bob = self._make_member(2, 'Bob')
+        a_bot = self._make_member(3, 'BotUser', is_bot=True)
+        unlinked = self._make_member(4, 'NoAccount')
+        guild = MagicMock(spec=discord.Guild)
+        guild.members = [alice, bob, a_bot, unlinked]
+
+        accounts = {
+            1: {'username': 'Alice', 'tag': 'NA1', 'puuid': 'pa'},
+            2: {'username': 'Bob', 'tag': 'NA1', 'puuid': 'pb'},
+        }
+        mock_valorant_client.get_linked_account.side_effect = lambda uid: accounts.get(uid)
+        mock_valorant_client.get_match_history = AsyncMock(
+            side_effect=lambda u, t, **kw: [{'puuid': accounts[1]['puuid'] if u == 'Alice' else accounts[2]['puuid']}]
+        )
+        mock_valorant_client.calculate_player_stats.side_effect = (
+            lambda matches, puuid, **kw: {'total_matches': 5, 'puuid': matches[0]['puuid']}
+        )
+
+        results = await self.cog._gather_member_stats(guild)
+
+        # Only Alice and Bob qualify (bot and unlinked excluded)
+        self.assertEqual({r['member'].display_name for r in results}, {'Alice', 'Bob'})
+        self.assertEqual(mock_valorant_client.get_match_history.await_count, 2)
+
+    @patch('commands.valorant_commands.valorant_client')
     async def test_weapon_leaderboard_success(self, mock_valorant_client):
         """Weapon leaderboard ranks members by kills with the chosen weapon."""
         alice = self._make_member(1, 'Alice')

--- a/tests/unit/commands/test_valorant_commands.py
+++ b/tests/unit/commands/test_valorant_commands.py
@@ -281,5 +281,74 @@ class TestValorantCommands(unittest.IsolatedAsyncioTestCase):
         verdict = next(f for f in embed.fields if f.name == 'Verdict')
         self.assertIn('Alice', verdict.value)
 
+    def _make_member(self, member_id, name, is_bot=False):
+        member = MagicMock(spec=discord.Member)
+        member.id = member_id
+        member.display_name = name
+        member.bot = is_bot
+        return member
+
+    @patch('commands.valorant_commands.valorant_client')
+    async def test_weapon_leaderboard_success(self, mock_valorant_client):
+        """Weapon leaderboard ranks members by kills with the chosen weapon."""
+        alice = self._make_member(1, 'Alice')
+        bob = self._make_member(2, 'Bob')
+        a_bot = self._make_member(3, 'BotUser', is_bot=True)
+        self.ctx.guild.members = [alice, bob, a_bot]
+
+        accounts = {
+            1: {'username': 'Alice', 'tag': 'NA1', 'puuid': 'pa'},
+            2: {'username': 'Bob', 'tag': 'NA1', 'puuid': 'pb'},
+        }
+        weapon_stats = {
+            'pa': {'total_matches': 5, 'weapon_kills': {'Vandal': 40, 'Phantom': 5}},
+            'pb': {'total_matches': 5, 'weapon_kills': {'Vandal': 60, 'Sheriff': 3}},
+        }
+        mock_valorant_client.get_linked_account.side_effect = lambda uid: accounts.get(uid)
+        mock_valorant_client.get_match_history = AsyncMock(
+            side_effect=lambda u, t, **kw: [{'puuid': accounts[1]['puuid'] if u == 'Alice' else accounts[2]['puuid']}]
+        )
+        mock_valorant_client.calculate_player_stats.side_effect = (
+            lambda matches, puuid, **kw: weapon_stats[matches[0]['puuid']]
+        )
+
+        await self.cog.weapon_leaderboard.callback(self.cog, self.ctx, weapon='vandal')
+
+        self.ctx.send.assert_awaited()
+        embed = self.ctx.send.call_args.kwargs['embed']
+        self.assertIn('Vandal', embed.title)
+        top = next(f for f in embed.fields if f.name == '🎯 Top Fraggers')
+        # Bob (60) should rank above Alice (40)
+        self.assertLess(top.value.index('Bob'), top.value.index('Alice'))
+        self.assertIn('60 kills', top.value)
+
+    @patch('commands.valorant_commands.valorant_client')
+    async def test_weapon_leaderboard_unknown_weapon(self, mock_valorant_client):
+        """An unrecognized weapon returns an error without querying stats."""
+        self.ctx.guild.members = []
+        await self.cog.weapon_leaderboard.callback(self.cog, self.ctx, weapon='banana')
+
+        self.cog.send_error_embed.assert_awaited_once()
+        mock_valorant_client.get_match_history.assert_not_called()
+
+    @patch('commands.valorant_commands.valorant_client')
+    async def test_weapon_leaderboard_no_kills(self, mock_valorant_client):
+        """When no one has kills with the weapon, a friendly message is shown."""
+        alice = self._make_member(1, 'Alice')
+        self.ctx.guild.members = [alice]
+        mock_valorant_client.get_linked_account.side_effect = (
+            lambda uid: {'username': 'Alice', 'tag': 'NA1', 'puuid': 'pa'} if uid == 1 else None
+        )
+        mock_valorant_client.get_match_history = AsyncMock(return_value=[{'puuid': 'pa'}])
+        mock_valorant_client.calculate_player_stats.return_value = {
+            'total_matches': 5, 'weapon_kills': {'Phantom': 10}
+        }
+
+        await self.cog.weapon_leaderboard.callback(self.cog, self.ctx, weapon='Operator')
+
+        self.cog.send_embed.assert_awaited()
+        self.ctx.send.assert_not_awaited()
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/unit/test_valorant_client.py
+++ b/tests/unit/test_valorant_client.py
@@ -231,6 +231,102 @@ class TestMatchHistoryAPI:
                 assert result == [{'id': 'match1'}]
 
 
+class TestWeaponKillTracking:
+    """Test per-weapon kill tracking in calculate_player_stats"""
+
+    @pytest.fixture
+    def client(self):
+        with patch('valorant_client.HENRIK_API_KEY', ''):
+            return ValorantClient()
+
+    def _build_match(self, player_puuid):
+        """Build a minimal competitive match with weapon-tagged kill events."""
+        return {
+            "metadata": {
+                "map": "Ascent",
+                "mode": "Competitive",
+                "mode_id": "competitive",
+                "queue": "competitive",
+                "rounds_played": 2,
+            },
+            "is_available": True,
+            "players": {
+                "all_players": [
+                    {
+                        "puuid": player_puuid,
+                        "team": "Red",
+                        "character": "Jett",
+                        "stats": {"kills": 3, "deaths": 1, "assists": 0,
+                                  "headshots": 2, "bodyshots": 1, "legshots": 0, "score": 600},
+                        "damage_made": 400,
+                        "damage_received": 200,
+                    }
+                ]
+            },
+            "teams": {"red": {"has_won": True}},
+            "rounds": [
+                {
+                    "winning_team": "Red",
+                    "player_stats": [
+                        {
+                            "player_puuid": player_puuid,
+                            "kills": 2,
+                            "kill_events": [
+                                {"victim_puuid": "v1", "kill_time_in_round": 1000,
+                                 "damage_weapon_name": "Vandal", "assistants": []},
+                                {"victim_puuid": "v2", "kill_time_in_round": 2000,
+                                 "damage_weapon_assets": {"display_name": "Phantom"}, "assistants": []},
+                            ],
+                        }
+                    ],
+                },
+                {
+                    "winning_team": "Red",
+                    "player_stats": [
+                        {
+                            "player_puuid": player_puuid,
+                            "kills": 1,
+                            "kill_events": [
+                                {"victim_puuid": "v3", "kill_time_in_round": 1500,
+                                 "damage_weapon_name": "Vandal", "assistants": []},
+                            ],
+                        }
+                    ],
+                },
+            ],
+        }
+
+    def test_weapon_kills_aggregated(self, client):
+        puuid = "player-1"
+        match = self._build_match(puuid)
+
+        with patch('valorant_client.database_manager.get_stored_player_stats', return_value=None), \
+             patch('valorant_client.database_manager.store_player_stats'):
+            stats = client.calculate_player_stats([match], puuid)
+
+        weapon_kills = stats.get('weapon_kills', {})
+        assert weapon_kills.get('Vandal') == 2
+        assert weapon_kills.get('Phantom') == 1
+
+    def test_weapon_kills_accumulate_across_matches(self, client):
+        puuid = "player-1"
+        matches = [self._build_match(puuid), self._build_match(puuid)]
+
+        with patch('valorant_client.database_manager.get_stored_player_stats', return_value=None), \
+             patch('valorant_client.database_manager.store_player_stats'):
+            stats = client.calculate_player_stats(matches, puuid)
+
+        assert stats['weapon_kills']['Vandal'] == 4
+        assert stats['weapon_kills']['Phantom'] == 2
+
+    def test_extract_weapon_name_fallbacks(self, client):
+        assert client._extract_weapon_name({"damage_weapon_name": "Sheriff"}) == "Sheriff"
+        assert client._extract_weapon_name(
+            {"damage_weapon_assets": {"display_name": "Operator"}}) == "Operator"
+        assert client._extract_weapon_name({"damage_weapon_id": "ability_id"}) == "ability_id"
+        assert client._extract_weapon_name({}) is None
+
+
 class TestGlobalInstance:
     """Test global instance"""
     

--- a/valorant_client.py
+++ b/valorant_client.py
@@ -424,7 +424,8 @@ class ValorantClient(BaseAPIClient):
             'agent_performance': {},
             'map_performance': {},
             'total_shots_fired': 0,
-            'total_shots_hit': 0
+            'total_shots_hit': 0,
+            'weapon_kills': {}  # weapon display name -> kill count across all matches
         }
         
         for match in matches:
@@ -509,6 +510,9 @@ class ValorantClient(BaseAPIClient):
             
             # Calculate accurate advanced stats for this match using the well-tested algorithm
             self._calculate_accurate_match_stats(match, player_puuid, stats, match_won)
+
+            # Track per-weapon kills from this match's round data
+            self._track_weapon_kills(match, player_puuid, stats)
             
             # Agent performance tracking
             if agent_name not in stats['agent_performance']:
@@ -659,6 +663,45 @@ class ValorantClient(BaseAPIClient):
         all_players = match.get('players', {}).get('all_players', [])
         return any(player.get('puuid') == player_puuid for player in all_players)
     
+    @staticmethod
+    def _extract_weapon_name(kill_event: Dict[str, Any]) -> Optional[str]:
+        """Extract a human-readable weapon name from a kill event.
+
+        Henrik API kill events expose the weapon via ``damage_weapon_name`` and/or
+        ``damage_weapon_assets.display_name``. We try the most reliable fields first
+        and fall back to the raw id so unknown weapons are still grouped consistently.
+        """
+        assets = kill_event.get("damage_weapon_assets") or {}
+        name = (
+            kill_event.get("damage_weapon_name")
+            or assets.get("display_name")
+            or kill_event.get("damage_weapon_id")
+        )
+        if not name:
+            return None
+        name = str(name).strip()
+        return name or None
+
+    def _track_weapon_kills(self, match: Dict[str, Any], player_puuid: str, stats: Dict[str, Any]):
+        """Tally the player's kills per weapon across all rounds of a match.
+
+        Note: the Henrik API only tags weapons on kill events, not on damage
+        events, so only per-weapon kill counts can be derived (not per-weapon
+        headshot/bodyshot/legshot accuracy).
+        """
+        weapon_kills = stats.setdefault('weapon_kills', {})
+
+        for round_data in match.get('rounds', []):
+            for player_round in round_data.get('player_stats', []):
+                if player_round.get('player_puuid') != player_puuid:
+                    continue
+
+                for kill_event in player_round.get('kill_events', []):
+                    weapon_name = self._extract_weapon_name(kill_event)
+                    if not weapon_name:
+                        continue
+                    weapon_kills[weapon_name] = weapon_kills.get(weapon_name, 0) + 1
+
     def _calculate_accurate_match_stats(self, match: Dict[str, Any], player_puuid: str, stats: Dict[str, Any], match_won: bool):
         """Calculate tournament-grade accurate match statistics using the proven algorithm from calculate_match_stats.py
         


### PR DESCRIPTION
## Summary
Adds a new weapon-specific leaderboard command and refactors stats gathering to use concurrent requests with rate-limit protection. Introduces per-weapon kill tracking to player statistics.

## Key Changes

- **New `/shootyweaponstats` command**: Server leaderboard ranking players by kills with a specific weapon (e.g., Vandal, Operator). Includes weapon autocomplete and case-insensitive matching.

- **Concurrent stats gathering**: Extracted stats collection into `_gather_member_stats()` helper method that fetches player stats concurrently with a semaphore (5 concurrent requests) to respect Henrik API rate limits.

- **Per-weapon kill tracking**: Enhanced `calculate_player_stats()` to track kills per weapon across all matches via new `_track_weapon_kills()` method. Extracts weapon names from kill events with fallback logic for API field variations.

- **Weapon configuration**: Added `VALORANT_WEAPONS` dict and `VALORANT_WEAPON_LIST` to `config.py` for centralized weapon definitions and autocomplete support.

- **Refactored leaderboard**: Updated existing `valorant_leaderboard` command to use the new concurrent helper, reducing code duplication and improving performance.

## Implementation Details

- **Weapon name extraction**: `_extract_weapon_name()` handles multiple API field formats (`damage_weapon_name`, `damage_weapon_assets.display_name`, `damage_weapon_id`) with graceful fallbacks.

- **Autocomplete handler**: `weapon_autocomplete()` provides case-insensitive weapon suggestions (max 25 results) for slash command input.

- **Rate limiting**: Semaphore-based concurrency control prevents overwhelming the Henrik API while gathering stats for all guild members.

- **Comprehensive test coverage**: Added 4 new unit tests covering stats gathering, weapon leaderboard success/error cases, and weapon name extraction logic.

https://claude.ai/code/session_01UzVDDjKMVWjCb3RDAjKPNX