### PR TITLE
Add rank/RR integration, head-to-head compare, and session recaps

### DIFF
--- a/match_tracker.py
+++ b/match_tracker.py
@@ -379,12 +379,12 @@ class MatchTracker:
             inline=False
         )
 
-        # Add rank / RR updates for the tracked squad (best-effort)
-        rank_updates = await self._get_squad_rank_updates(discord_members)
-        if rank_updates:
+        # Celebrate any squad members who ranked up this game (best-effort)
+        rank_ups = await self._get_squad_rank_ups(discord_members)
+        if rank_ups:
             embed.add_field(
-                name="📈 Rank Updates",
-                value=rank_updates,
+                name="🎉 Rank Up!",
+                value=rank_ups,
                 inline=False
             )
 
@@ -449,11 +449,17 @@ class MatchTracker:
         embed.set_footer(text="Use /shootylink to show up in post-match recaps!")
         return embed
 
-    async def _get_squad_rank_updates(self, discord_members: List[Dict]) -> Optional[str]:
-        """Build a rank/RR update line for each tracked squad member.
+    async def _get_squad_rank_ups(self, discord_members: List[Dict]) -> Optional[str]:
+        """Build celebratory lines for squad members who ranked up this game.
 
-        Best-effort: skips members whose MMR can't be fetched (private profile,
-        API down, no key) so the recap still renders without them.
+        Only includes players who crossed up at least one full tier as a result
+        of their most recent game. A promotion is detected when the last game's
+        RR gain pushed them past a tier boundary: their pre-game RR-in-tier
+        (``ranking_in_tier - mmr_change``) was below zero.
+
+        Best-effort: silently skips members whose MMR can't be fetched (private
+        profile, API down, no key). Returns ``None`` when nobody ranked up, so
+        callers can omit the field entirely and keep recaps quiet.
         """
         lines = []
         for dm in discord_members:
@@ -472,23 +478,19 @@ class MatchTracker:
             if not mmr or not mmr.get('tier'):
                 continue
 
-            member = dm['member']
             rr = mmr.get('rr')
             change = mmr.get('rr_change')
-            rr_str = f"{rr} RR" if rr is not None else ""
 
-            if change is None:
-                change_str = ""
-            elif change > 0:
-                change_str = f" (🟢 +{change})"
-            elif change < 0:
-                change_str = f" (🔴 {change})"
-            else:
-                change_str = " (⚪ ±0)"
+            # Only celebrate genuine promotions: a positive RR change whose
+            # pre-game RR-in-tier was negative means a tier boundary was crossed.
+            if rr is None or change is None or change <= 0:
+                continue
+            if (rr - change) >= 0:
+                continue
 
-            sep = " · " if rr_str else ""
+            member = dm['member']
             lines.append(
-                f"• **{member.display_name}**: {mmr.get('emoji', '')} {mmr['tier']}{sep}{rr_str}{change_str}"
+                f"🎉 **{member.display_name}** ranked up to {mmr.get('emoji', '')} **{mmr['tier']}**!"
             )
 
         return "\n".join(lines) if lines else None

--- a/match_tracker.py
+++ b/match_tracker.py
@@ -329,6 +329,9 @@ class MatchTracker:
         team_won = False
         tracked_puuids = set()
 
+        # Members who crossed up a full tier this game (shown inline)
+        ranked_up_ids = await self._get_ranked_up_member_ids(discord_members)
+
         for dm in discord_members:
             member = dm['member']
             player_data = dm['player_data']
@@ -348,7 +351,8 @@ class MatchTracker:
             kda = f"{stats.get('kills', 0)}/{stats.get('deaths', 0)}/{stats.get('assists', 0)}"
             rank = get_player_rank(player_data)
             rank_str = f" • {rank_emoji(rank)} {rank}" if rank else ""
-            member_list.append(f"• **{member.display_name}**: {kda}{rank_str}")
+            rankup_str = " ⬆️ **Rank Up!**" if member.id in ranked_up_ids else ""
+            member_list.append(f"• **{member.display_name}**: {kda}{rank_str}{rankup_str}")
 
         # Add untracked teammates (players on the same team who aren't linked via shootylink)
         all_players = match.get('players', {}).get('all_players', [])
@@ -378,15 +382,6 @@ class MatchTracker:
             value="\n".join(member_list) if member_list else "No squad members found",
             inline=False
         )
-
-        # Celebrate any squad members who ranked up this game (best-effort)
-        rank_ups = await self._get_squad_rank_ups(discord_members)
-        if rank_ups:
-            embed.add_field(
-                name="🎉 Rank Up!",
-                value=rank_ups,
-                inline=False
-            )
 
         # Add enhanced fun highlights
         if fun_stats['highlights']:
@@ -449,19 +444,17 @@ class MatchTracker:
         embed.set_footer(text="Use /shootylink to show up in post-match recaps!")
         return embed
 
-    async def _get_squad_rank_ups(self, discord_members: List[Dict]) -> Optional[str]:
-        """Build celebratory lines for squad members who ranked up this game.
+    async def _get_ranked_up_member_ids(self, discord_members: List[Dict]) -> set:
+        """Return the ids of squad members who crossed up a full tier this game.
 
-        Only includes players who crossed up at least one full tier as a result
-        of their most recent game. A promotion is detected when the last game's
-        RR gain pushed them past a tier boundary: their pre-game RR-in-tier
+        A promotion is detected when the last game's RR gain pushed the player
+        past a tier boundary: their pre-game RR-in-tier
         (``ranking_in_tier - mmr_change``) was below zero.
 
         Best-effort: silently skips members whose MMR can't be fetched (private
-        profile, API down, no key). Returns ``None`` when nobody ranked up, so
-        callers can omit the field entirely and keep recaps quiet.
+        profile, API down, no key), so the recap still renders without them.
         """
-        lines = []
+        ranked_up = set()
         for dm in discord_members:
             account = dm.get('account', {}) or {}
             username = account.get('username')
@@ -475,25 +468,21 @@ class MatchTracker:
                 log_error(f"fetching rank for {username}#{tag}", e)
                 mmr = None
 
-            if not mmr or not mmr.get('tier'):
+            if not mmr:
                 continue
 
             rr = mmr.get('rr')
             change = mmr.get('rr_change')
-
-            # Only celebrate genuine promotions: a positive RR change whose
-            # pre-game RR-in-tier was negative means a tier boundary was crossed.
+            # Genuine promotion: a positive RR change whose pre-game RR-in-tier
+            # was negative means a tier boundary was crossed this game.
             if rr is None or change is None or change <= 0:
                 continue
             if (rr - change) >= 0:
                 continue
 
-            member = dm['member']
-            lines.append(
-                f"🎉 **{member.display_name}** ranked up to {mmr.get('emoji', '')} **{mmr['tier']}**!"
-            )
+            ranked_up.add(dm['member'].id)
 
-        return "\n".join(lines) if lines else None
+        return ranked_up
 
     async def build_session_recap(self, guild: discord.Guild, participants: List[discord.Member], session) -> discord.Embed:
         """Build an end-of-session recap embed.

--- a/tests/unit/test_rank_features.py
+++ b/tests/unit/test_rank_features.py
@@ -119,7 +119,7 @@ async def test_match_embed_shows_player_rank(discord_member_factory):
     with patch('match_tracker.format_time_ago', return_value='just now'), \
          patch.object(tracker, '_calculate_fun_match_stats',
                       return_value={'highlights': [], 'top_performers': {}, 'funny_stats': {}}), \
-         patch.object(tracker, '_get_squad_rank_updates', AsyncMock(return_value=None)):
+         patch.object(tracker, '_get_squad_rank_ups', AsyncMock(return_value=None)):
         embed = await tracker._create_match_embed(match, discord_members)
 
     squad_field = next(f for f in embed.fields if 'Squad' in f.name)
@@ -127,32 +127,71 @@ async def test_match_embed_shows_player_rank(discord_member_factory):
 
 
 # ---------------------------------------------------------------------------
-# _get_squad_rank_updates
+# _get_squad_rank_ups (celebratory: only on a full-tier promotion)
 # ---------------------------------------------------------------------------
 
 @pytest.mark.asyncio
-async def test_squad_rank_updates_formats_rr_change(discord_member_factory):
+async def test_squad_rank_up_celebrated_on_promotion(discord_member_factory):
     bot = MagicMock(spec=discord.Client)
     tracker = MatchTracker(bot)
     member = discord_member_factory(user_id=1, name='Player1')
     discord_members = [{'member': member,
                         'account': {'puuid': 'p1', 'username': 'Player1', 'tag': 'NA1'}}]
 
+    # rr=5, change=+18 -> pre-game RR-in-tier was -13 -> crossed a tier boundary
+    fake_client = MagicMock()
+    fake_client.get_mmr = AsyncMock(return_value={
+        'tier': 'Diamond 1', 'rr': 5, 'rr_change': 18, 'emoji': '💎', 'peak': 'Diamond 1',
+    })
+    with patch('match_tracker.valorant_client', fake_client):
+        result = await tracker._get_squad_rank_ups(discord_members)
+
+    assert result is not None
+    assert 'ranked up' in result
+    assert 'Player1' in result
+    assert 'Diamond 1' in result
+
+
+@pytest.mark.asyncio
+async def test_squad_rank_up_silent_without_promotion(discord_member_factory):
+    bot = MagicMock(spec=discord.Client)
+    tracker = MatchTracker(bot)
+    member = discord_member_factory(user_id=1, name='Player1')
+    discord_members = [{'member': member,
+                        'account': {'puuid': 'p1', 'username': 'Player1', 'tag': 'NA1'}}]
+
+    # rr=45, change=+18 -> pre-game RR was 27, no boundary crossed -> no field
     fake_client = MagicMock()
     fake_client.get_mmr = AsyncMock(return_value={
         'tier': 'Diamond 1', 'rr': 45, 'rr_change': 18, 'emoji': '💎', 'peak': 'Diamond 2',
     })
     with patch('match_tracker.valorant_client', fake_client):
-        result = await tracker._get_squad_rank_updates(discord_members)
+        result = await tracker._get_squad_rank_ups(discord_members)
 
-    assert 'Player1' in result
-    assert 'Diamond 1' in result
-    assert '45 RR' in result
-    assert '+18' in result
+    assert result is None
 
 
 @pytest.mark.asyncio
-async def test_squad_rank_updates_skips_accounts_without_credentials(discord_member_factory):
+async def test_squad_rank_up_silent_on_rr_loss(discord_member_factory):
+    bot = MagicMock(spec=discord.Client)
+    tracker = MatchTracker(bot)
+    member = discord_member_factory(user_id=1, name='Player1')
+    discord_members = [{'member': member,
+                        'account': {'puuid': 'p1', 'username': 'Player1', 'tag': 'NA1'}}]
+
+    # Negative RR change is never a rank up, even at low RR
+    fake_client = MagicMock()
+    fake_client.get_mmr = AsyncMock(return_value={
+        'tier': 'Diamond 1', 'rr': 5, 'rr_change': -16, 'emoji': '💎', 'peak': 'Diamond 2',
+    })
+    with patch('match_tracker.valorant_client', fake_client):
+        result = await tracker._get_squad_rank_ups(discord_members)
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_squad_rank_up_skips_accounts_without_credentials(discord_member_factory):
     bot = MagicMock(spec=discord.Client)
     tracker = MatchTracker(bot)
     member = discord_member_factory(user_id=1, name='Player1')
@@ -162,7 +201,7 @@ async def test_squad_rank_updates_skips_accounts_without_credentials(discord_mem
     fake_client = MagicMock()
     fake_client.get_mmr = AsyncMock()
     with patch('match_tracker.valorant_client', fake_client):
-        result = await tracker._get_squad_rank_updates(discord_members)
+        result = await tracker._get_squad_rank_ups(discord_members)
 
     assert result is None
     fake_client.get_mmr.assert_not_called()

--- a/tests/unit/test_rank_features.py
+++ b/tests/unit/test_rank_features.py
@@ -119,19 +119,56 @@ async def test_match_embed_shows_player_rank(discord_member_factory):
     with patch('match_tracker.format_time_ago', return_value='just now'), \
          patch.object(tracker, '_calculate_fun_match_stats',
                       return_value={'highlights': [], 'top_performers': {}, 'funny_stats': {}}), \
-         patch.object(tracker, '_get_squad_rank_ups', AsyncMock(return_value=None)):
+         patch.object(tracker, '_get_ranked_up_member_ids', AsyncMock(return_value=set())):
         embed = await tracker._create_match_embed(match, discord_members)
 
     squad_field = next(f for f in embed.fields if 'Squad' in f.name)
     assert 'Diamond 1' in squad_field.value
+    # No rank-up marker when the member didn't get promoted
+    assert 'Rank Up!' not in squad_field.value
+
+
+@pytest.mark.asyncio
+async def test_match_embed_shows_inline_rank_up(discord_member_factory):
+    """A promoted member is flagged inline in the squad list (no separate field)."""
+    bot = MagicMock(spec=discord.Client)
+    tracker = MatchTracker(bot)
+
+    match = {
+        'metadata': {
+            'map': 'Ascent', 'rounds_played': 13, 'game_length': 1800,
+            'game_start': '2024-01-01T00:00:00Z', 'matchid': 'abc123',
+        },
+        'teams': {'red': {'has_won': True, 'rounds_won': 13},
+                  'blue': {'has_won': False, 'rounds_won': 8}},
+        'players': {'all_players': [
+            {'puuid': 'p1', 'name': 'Tracked', 'tag': 'NA1', 'team': 'Red',
+             'currenttier_patched': 'Diamond 1', 'currenttier': 18,
+             'stats': {'kills': 20, 'deaths': 10, 'assists': 5}},
+        ]},
+    }
+    member = discord_member_factory(user_id=1, name='TrackedName')
+    discord_members = [{'member': member, 'account': {'puuid': 'p1'},
+                        'player_data': match['players']['all_players'][0]}]
+
+    with patch('match_tracker.format_time_ago', return_value='just now'), \
+         patch.object(tracker, '_calculate_fun_match_stats',
+                      return_value={'highlights': [], 'top_performers': {}, 'funny_stats': {}}), \
+         patch.object(tracker, '_get_ranked_up_member_ids', AsyncMock(return_value={1})):
+        embed = await tracker._create_match_embed(match, discord_members)
+
+    squad_field = next(f for f in embed.fields if 'Squad' in f.name)
+    assert 'Rank Up!' in squad_field.value
+    # The promotion is inline, not a separate field
+    assert not any('Rank Up' in f.name for f in embed.fields)
 
 
 # ---------------------------------------------------------------------------
-# _get_squad_rank_ups (celebratory: only on a full-tier promotion)
+# _get_ranked_up_member_ids (inline marker only on a full-tier promotion)
 # ---------------------------------------------------------------------------
 
 @pytest.mark.asyncio
-async def test_squad_rank_up_celebrated_on_promotion(discord_member_factory):
+async def test_ranked_up_detected_on_promotion(discord_member_factory):
     bot = MagicMock(spec=discord.Client)
     tracker = MatchTracker(bot)
     member = discord_member_factory(user_id=1, name='Player1')
@@ -144,35 +181,32 @@ async def test_squad_rank_up_celebrated_on_promotion(discord_member_factory):
         'tier': 'Diamond 1', 'rr': 5, 'rr_change': 18, 'emoji': '💎', 'peak': 'Diamond 1',
     })
     with patch('match_tracker.valorant_client', fake_client):
-        result = await tracker._get_squad_rank_ups(discord_members)
+        result = await tracker._get_ranked_up_member_ids(discord_members)
 
-    assert result is not None
-    assert 'ranked up' in result
-    assert 'Player1' in result
-    assert 'Diamond 1' in result
+    assert result == {1}
 
 
 @pytest.mark.asyncio
-async def test_squad_rank_up_silent_without_promotion(discord_member_factory):
+async def test_ranked_up_empty_without_promotion(discord_member_factory):
     bot = MagicMock(spec=discord.Client)
     tracker = MatchTracker(bot)
     member = discord_member_factory(user_id=1, name='Player1')
     discord_members = [{'member': member,
                         'account': {'puuid': 'p1', 'username': 'Player1', 'tag': 'NA1'}}]
 
-    # rr=45, change=+18 -> pre-game RR was 27, no boundary crossed -> no field
+    # rr=45, change=+18 -> pre-game RR was 27, no boundary crossed
     fake_client = MagicMock()
     fake_client.get_mmr = AsyncMock(return_value={
         'tier': 'Diamond 1', 'rr': 45, 'rr_change': 18, 'emoji': '💎', 'peak': 'Diamond 2',
     })
     with patch('match_tracker.valorant_client', fake_client):
-        result = await tracker._get_squad_rank_ups(discord_members)
+        result = await tracker._get_ranked_up_member_ids(discord_members)
 
-    assert result is None
+    assert result == set()
 
 
 @pytest.mark.asyncio
-async def test_squad_rank_up_silent_on_rr_loss(discord_member_factory):
+async def test_ranked_up_empty_on_rr_loss(discord_member_factory):
     bot = MagicMock(spec=discord.Client)
     tracker = MatchTracker(bot)
     member = discord_member_factory(user_id=1, name='Player1')
@@ -185,25 +219,25 @@ async def test_squad_rank_up_silent_on_rr_loss(discord_member_factory):
         'tier': 'Diamond 1', 'rr': 5, 'rr_change': -16, 'emoji': '💎', 'peak': 'Diamond 2',
     })
     with patch('match_tracker.valorant_client', fake_client):
-        result = await tracker._get_squad_rank_ups(discord_members)
+        result = await tracker._get_ranked_up_member_ids(discord_members)
 
-    assert result is None
+    assert result == set()
 
 
 @pytest.mark.asyncio
-async def test_squad_rank_up_skips_accounts_without_credentials(discord_member_factory):
+async def test_ranked_up_skips_accounts_without_credentials(discord_member_factory):
     bot = MagicMock(spec=discord.Client)
     tracker = MatchTracker(bot)
     member = discord_member_factory(user_id=1, name='Player1')
-    # No username/tag -> should not trigger an API call and returns None
+    # No username/tag -> should not trigger an API call
     discord_members = [{'member': member, 'account': {'puuid': 'p1'}}]
 
     fake_client = MagicMock()
     fake_client.get_mmr = AsyncMock()
     with patch('match_tracker.valorant_client', fake_client):
-        result = await tracker._get_squad_rank_ups(discord_members)
+        result = await tracker._get_ranked_up_member_ids(discord_members)
 
-    assert result is None
+    assert result == set()
     fake_client.get_mmr.assert_not_called()
 
 


### PR DESCRIPTION
Ships three post-game UX features that build on the existing tournament-grade stat infrastructure.

## 1. Rank / RR integration
- New `ValorantClient.get_mmr()` fetches current tier, RR, last-game RR change, elo, and peak rank from Henrik's v2 MMR endpoint (same base-URL-swap pattern as `get_match_history`).
- Helpers `tier_name` / `rank_emoji` / `get_player_rank` map Henrik's numeric tiers to names + emoji.
- Post-match recaps show each squad member's **rank inline** next to their K/D/A. When a player crosses up a full tier that game, an **⬆️ Rank Up!** marker appears inline next to their name — celebratory and quiet (nothing shown otherwise, no per-game RR noise).
- New **`/shootyrank [member] [account]`** for on-demand rank, RR, peak, and elo.

## 2. `/shootycompare <player1> [player2]`
- Side-by-side head-to-head across ACS, K/D, KDA, KAST, ADR, HS%, win rate, first-blood rate, and clutch %, with a ★ on each category leader and a verdict line. Reuses `calculate_player_stats`; defaults the second player to the caller and appends both players' current ranks.

## 3. Session recap at `/stend`
- `MatchTracker.build_session_recap` ties a session to the competitive matches its participants played during the session window: games count, W-L, a per-player scoreboard sorted by KDA, **👑 MVP of the night**, and end-of-night ranks. Falls back to a friendly "no tracked games" card when no data is available, so non-Valorant sessions still get a clean summary.

Help text updated for the new commands.

## Notes
- Rank/RR features require `HENRIK_API_KEY` (the MMR endpoint needs auth, like match history already does). Without it, the rank bits gracefully no-op and everything else still works.
- All rank lookups are best-effort: if MMR can't be fetched (private profile, API down), the recap still renders without the rank/rank-up bits.

## Testing
- New `tests/unit/test_rank_features.py`: rank helpers, `get_mmr` parsing/failure/exception paths (incl. base-URL restoration), inline rank-up detection (promotion / no-promotion / RR-loss / missing-credentials), and session recap (games / no-games / out-of-window filtering).
- New command tests for `/shootyrank` and `/shootycompare`.
- Full unit suite: **173 passed**, 3 skipped. The only 2 failures (`test_bot.py::TestCommandSync`) are pre-existing on `main` and unrelated to this change.

https://claude.ai/code/session_01Mx37qcpPdSxKN3RPz5236C

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mx37qcpPdSxKN3RPz5236C)_