### PR TITLE
Refactor Henrik API usage: lightweight endpoints + SQLite caching

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,10 +8,16 @@ BOT_TOKEN=your_bot_token_here
 # Format: <@&ROLE_ID> - get this by typing \@RoleName in Discord
 SHOOTY_ROLE_CODE=<@&773770148070424657>
 
-# Henrik API Key (optional - for higher rate limits)
-# Get Advanced key from https://docs.henrikdev.xyz
-# Leave empty to use Basic tier (30 req/min, no key needed)
+# Henrik API Key (now required by Henrik for most endpoints)
+# Get a key from https://docs.henrikdev.xyz (join their Discord)
+# Basic keys allow 30 req/min, Advanced keys 90 req/min
 HENRIK_API_KEY=
+
+# Requests per minute for your Henrik key tier (Basic=30, Advanced=90)
+HENRIK_REQUESTS_PER_MINUTE=30
+
+# Valorant region for all Henrik API calls (ap, br, eu, kr, latam, na)
+VALORANT_REGION=na
 
 # Logging level (optional)
 LOG_LEVEL=INFO

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -314,6 +314,46 @@ python3 test_database_fast.py
 4. Commit with descriptive commit message
 5. Deploy to production with proper process management
 
+## Henrik API Usage Architecture
+
+ShootyBot uses a tiered approach to keep Henrik API usage cheap and fast:
+
+### Endpoint Tiers (cheapest first):
+1. **SQLite (free)**: Completed matches are immutable - full match JSON is permanently
+   cached in `henrik_matches`, and per-player computed stats live in `player_match_stats`
+   (one row per puuid+match, computed exactly once).
+2. **Lightweight endpoints (few KB, served from Henrik's DB/cache)**:
+   - `v1/by-puuid/stored-matches/{region}/{puuid}` - match id discovery + basic scoreboard
+   - `v1/by-puuid/mmr-history/{region}/{puuid}` - live competitive updates (new-match polling)
+   - `v2/by-puuid/mmr/{region}/{puuid}` - current rank/RR
+3. **Heavy endpoints (multi-MB, live Riot fetch)**:
+   - `v3/by-puuid/matches/{region}/{puuid}` - full matchlist (**size capped at 10 by the API**)
+   - `v2/match/{matchid}` - single match details
+
+### Key Rules:
+- **Always prefer by-puuid endpoints** - they skip Riot-ID resolution and survive renames.
+  PUUIDs starting with `manual_` are placeholders from `/shootymanuallink` and must not be
+  sent to by-puuid endpoints (`ValorantClient._usable_puuid` handles this).
+- **Never mutate `base_url`** - endpoint paths carry their version prefix (`v1/...`, `v3/...`).
+- **Stats flow**: commands call `get_player_stats()` which discovers recent match ids via
+  lightweight endpoints, reuses `player_match_stats` rows, fetches only unseen matches
+  (one bulk matchlist call if >=3 missing, else per-match), and aggregates rows.
+  `calculate_player_stats()` is the pure in-memory equivalent (no API/DB) used by legacy
+  paths and tests.
+- **Match tracker polling**: polls `get_recent_competitive_updates()` (few KB) per minute;
+  full match details are fetched at most once per new match id, then stat rows are recorded
+  for every linked player in the match (`record_match_stats_for_players`).
+- **4xx responses are returned, not retried** - only 429 (after waiting) and 5xx/network
+  errors go through retry with backoff. Henrik's `x-ratelimit-remaining`/`x-ratelimit-reset`
+  headers are honored before sending requests.
+- **Adding new statlines**: extend the row dict in `build_match_stats_row()` (and the
+  `player_match_stats` schema / `extra` JSON column), then fold it in `aggregate_match_rows()`.
+  Historical rows can be recomputed from permanently stored matches without API calls.
+
+### Configuration:
+- `HENRIK_API_KEY` (required by Henrik), `HENRIK_REQUESTS_PER_MINUTE` (Basic=30, Advanced=90),
+  `VALORANT_REGION` (default `na`).
+
 ## Advanced Valorant Statistics & API Analysis
 
 ### Henrik API Stats Calculation

--- a/api_clients.py
+++ b/api_clients.py
@@ -64,6 +64,11 @@ class BaseAPIClient(ABC):
         self._cache: Dict[str, Any] = {}
         self._cache_ttl: Dict[str, datetime] = {}
         self._request_times: List[datetime] = []
+        self._requests_since_cache_sweep = 0
+
+        # Server-reported rate limit state (from response headers)
+        self._server_requests_remaining: Optional[int] = None
+        self._server_limit_resets_at: Optional[datetime] = None
         
     async def __aenter__(self):
         """Async context manager entry."""
@@ -157,20 +162,33 @@ class BaseAPIClient(ABC):
     async def _check_rate_limit(self) -> None:
         """Check and enforce rate limits."""
         now = datetime.utcnow()
-        
+
+        # Honor the server-reported window first: if the API told us we have no
+        # requests left, wait until its reset time instead of guessing locally.
+        if (self._server_requests_remaining is not None
+                and self._server_requests_remaining <= 0
+                and self._server_limit_resets_at is not None):
+            wait_time = (self._server_limit_resets_at - now).total_seconds()
+            if 0 < wait_time <= 120:
+                self.logger.warning(f"Server rate limit exhausted, waiting {wait_time:.1f}s for reset")
+                await asyncio.sleep(wait_time)
+                now = datetime.utcnow()
+            self._server_requests_remaining = None
+            self._server_limit_resets_at = None
+
         # Clean old request times
         cutoff = now - timedelta(seconds=60)
         self._request_times = [t for t in self._request_times if t > cutoff]
-        
+
         # Check rate limit
         if len(self._request_times) >= self.rate_limit.requests_per_minute:
             oldest_request = min(self._request_times)
             wait_time = 60 - (now - oldest_request).total_seconds()
-            
+
             if wait_time > 0:
                 self.logger.warning(f"Rate limit reached, waiting {wait_time:.1f}s")
                 await asyncio.sleep(wait_time)
-        
+
         # Record this request
         self._request_times.append(now)
     
@@ -196,7 +214,13 @@ class BaseAPIClient(ABC):
         
         # Check rate limit
         await self._check_rate_limit()
-        
+
+        # Periodically evict stale cache entries so memory stays bounded
+        self._requests_since_cache_sweep += 1
+        if self._requests_since_cache_sweep >= 50:
+            self._requests_since_cache_sweep = 0
+            self._clear_expired_cache()
+
         # Make request
         url = f"{self.base_url}/{endpoint.lstrip('/')}"
         
@@ -210,19 +234,19 @@ class BaseAPIClient(ABC):
                 
                 headers = dict(response.headers)
                 status_code = response.status
-                
+
                 # Parse rate limit info from headers
                 rate_limit_info = self._parse_rate_limit_headers(headers)
-                
+
                 # Handle different content types
                 if 'application/json' in response.headers.get('content-type', ''):
                     response_data = await response.json()
                 else:
                     response_data = {'text': await response.text()}
-                
+
                 # Handle rate limiting
                 if status_code == 429:
-                    retry_after = int(headers.get('retry-after', 60))
+                    retry_after = self._get_retry_after_seconds(headers)
                     self.logger.warning(f"Rate limited, retry after {retry_after}s")
                     await asyncio.sleep(retry_after)
                     raise aiohttp.ClientResponseError(
@@ -231,17 +255,18 @@ class BaseAPIClient(ABC):
                         status=status_code,
                         message="Rate limited"
                     )
-                
-                # Handle client errors
+
+                # Other client errors (404 not found, 401 unauthorized, ...) are
+                # not transient: return them so callers can branch on status_code
+                # instead of burning retries with backoff on a guaranteed failure.
                 if 400 <= status_code < 500:
-                    error_msg = response_data.get('message', f"Client error: {status_code}")
-                    raise aiohttp.ClientResponseError(
-                        request_info=response.request_info,
-                        history=response.history,
-                        status=status_code,
-                        message=error_msg
+                    return APIResponse(
+                        data=response_data,
+                        status_code=status_code,
+                        headers=headers,
+                        rate_limit_info=rate_limit_info
                     )
-                
+
                 # Handle server errors
                 if status_code >= 500:
                     error_msg = f"Server error: {status_code}"
@@ -270,9 +295,41 @@ class BaseAPIClient(ABC):
             log_error(f"unexpected error in {method} request to {endpoint}", e)
             raise
     
-    def _parse_rate_limit_headers(self, headers: Dict[str, str]) -> Optional[RateLimitInfo]:
-        """Parse rate limit information from response headers (override in subclass)."""
+    @staticmethod
+    def _header_lookup(headers: Dict[str, str], name: str) -> Optional[str]:
+        """Case-insensitive header lookup on a plain dict."""
+        lowered = name.lower()
+        for key, value in headers.items():
+            if key.lower() == lowered:
+                return value
         return None
+
+    def _get_retry_after_seconds(self, headers: Dict[str, str], default: int = 30) -> int:
+        """Determine how long to wait after a 429, capped to avoid stalling callers."""
+        for header in ('retry-after', 'x-ratelimit-reset'):
+            value = self._header_lookup(headers, header)
+            if value is not None:
+                try:
+                    return max(1, min(int(float(value)), 60))
+                except (TypeError, ValueError):
+                    continue
+        return default
+
+    def _parse_rate_limit_headers(self, headers: Dict[str, str]) -> Optional[RateLimitInfo]:
+        """Parse standard x-ratelimit-* headers and track the server-side window."""
+        remaining = self._header_lookup(headers, 'x-ratelimit-remaining')
+        reset = self._header_lookup(headers, 'x-ratelimit-reset')
+        if remaining is None:
+            return None
+        try:
+            self._server_requests_remaining = int(remaining)
+            if reset is not None:
+                # Henrik reports seconds until the window resets
+                reset_seconds = min(int(float(reset)), 120)
+                self._server_limit_resets_at = datetime.utcnow() + timedelta(seconds=reset_seconds)
+        except (TypeError, ValueError):
+            return None
+        return self.rate_limit
     
     async def get(self, endpoint: str, params: Dict[str, Any] = None,
                  use_cache: bool = True, cache_ttl: int = 300) -> APIResponse[Dict[str, Any]]:

--- a/commands/valorant_commands.py
+++ b/commands/valorant_commands.py
@@ -432,25 +432,23 @@ class ValorantCommands(BaseCommandCog):
                 if not selected_account:
                     selected_account = accounts[0]
             
-            # Fetch match history (competitive only for accurate stats)
-            matches = await valorant_client.get_match_history(
-                selected_account['username'], 
-                selected_account['tag'], 
+            # Aggregate stats over recent competitive matches (incremental:
+            # only unseen matches are fetched, the rest come from SQLite)
+            stats = await valorant_client.get_player_stats(
+                selected_account['username'],
+                selected_account['tag'],
                 size=20,  # Analyze last 20 matches
                 mode='competitive'  # Only analyze competitive matches
             )
-            
-            if not matches:
+
+            if stats is None:
                 await self.send_error_embed(
                     ctx,
                     "No Match Data",
                     "Could not fetch match history. Account may be private or no recent matches found."
                 )
                 return
-            
-            # Calculate comprehensive stats
-            stats = valorant_client.calculate_player_stats(matches, selected_account['puuid'])
-            
+
             if not stats or stats.get('total_matches', 0) == 0:
                 await self.send_error_embed(
                     ctx,
@@ -595,7 +593,8 @@ class ValorantCommands(BaseCommandCog):
             else:
                 selected_account = valorant_client.get_linked_account(target_user.id) or accounts[0]
 
-            mmr = await valorant_client.get_mmr(selected_account['username'], selected_account['tag'])
+            mmr = await valorant_client.get_mmr(selected_account['username'], selected_account['tag'],
+                                                puuid=selected_account.get('puuid'))
             if not mmr or not mmr.get('tier'):
                 await self.send_error_embed(
                     ctx, "No Rank Data",
@@ -667,17 +666,16 @@ class ValorantCommands(BaseCommandCog):
                     )
                     return
 
-                matches = await valorant_client.get_match_history(
+                stats = await valorant_client.get_player_stats(
                     account['username'], account['tag'], size=20, mode='competitive'
                 )
-                if not matches:
+                if stats is None:
                     await self.send_error_embed(
                         ctx, "No Match Data",
                         f"Could not fetch competitive match history for {member.display_name}."
                     )
                     return
 
-                stats = valorant_client.calculate_player_stats(matches, account['puuid'])
                 if not stats or stats.get('total_matches', 0) == 0:
                     await self.send_error_embed(
                         ctx, "No Stats Available",
@@ -740,8 +738,10 @@ class ValorantCommands(BaseCommandCog):
             embed.add_field(name="Verdict", value=verdict, inline=False)
 
             # Current ranks (best-effort)
-            rank_a = await valorant_client.get_mmr(a['account']['username'], a['account']['tag'])
-            rank_b = await valorant_client.get_mmr(b['account']['username'], b['account']['tag'])
+            rank_a = await valorant_client.get_mmr(a['account']['username'], a['account']['tag'],
+                                                   puuid=a['account'].get('puuid'))
+            rank_b = await valorant_client.get_mmr(b['account']['username'], b['account']['tag'],
+                                                   puuid=b['account'].get('puuid'))
             if (rank_a and rank_a.get('tier')) or (rank_b and rank_b.get('tier')):
                 ra = f"{rank_a.get('emoji', '')} {rank_a['tier']}" if rank_a and rank_a.get('tier') else "Unranked"
                 rb = f"{rank_b.get('emoji', '')} {rank_b['tier']}" if rank_b and rank_b.get('tier') else "Unranked"
@@ -776,12 +776,11 @@ class ValorantCommands(BaseCommandCog):
         async def fetch(member: discord.Member, account: dict) -> Optional[dict]:
             async with semaphore:
                 try:
-                    matches = await valorant_client.get_match_history(
-                        account['username'], account['tag'], size=size
+                    stats = await valorant_client.get_player_stats(
+                        account['username'], account['tag'], size=size, mode='competitive'
                     )
-                    if not matches:
+                    if not stats:
                         return None
-                    stats = valorant_client.calculate_player_stats(matches, account['puuid'])
                     return {'member': member, 'account': account, 'stats': stats}
                 except Exception as e:
                     self.logger.warning(f"Error getting stats for {member.display_name}: {e}")
@@ -1344,24 +1343,22 @@ class ValorantCommands(BaseCommandCog):
             if not selected_account:
                 selected_account = accounts[0]
             
-            # Fetch match history
-            matches = await valorant_client.get_match_history(
-                selected_account['username'], 
-                selected_account['tag'], 
-                size=20
+            # Aggregate competitive stats (incremental fetch + SQLite rows)
+            stats = await valorant_client.get_player_stats(
+                selected_account['username'],
+                selected_account['tag'],
+                size=20,
+                mode='competitive'
             )
-            
-            if not matches:
+
+            if stats is None:
                 await self.send_error_embed(
                     ctx,
                     "No Match Data",
                     "Could not fetch match history for fun stats analysis."
                 )
                 return
-            
-            # Calculate stats
-            stats = valorant_client.calculate_player_stats(matches, selected_account['puuid'])
-            
+
             if not stats or stats.get('total_matches', 0) == 0:
                 await self.send_error_embed(
                     ctx,

--- a/config.py
+++ b/config.py
@@ -26,6 +26,11 @@ DATA_DIR = os.getenv("DATA_DIR", "data")
 
 # Henrik API Configuration
 HENRIK_API_KEY = os.getenv("HENRIK_API_KEY", "")
+# Default Valorant region for all Henrik API calls (ap, br, eu, kr, latam, na)
+VALORANT_REGION = os.getenv("VALORANT_REGION", "na")
+# Requests per minute allowed by your Henrik key tier:
+# Basic keys = 30/min, Advanced keys = 90/min (see docs.henrikdev.xyz)
+HENRIK_REQUESTS_PER_MINUTE = int(os.getenv("HENRIK_REQUESTS_PER_MINUTE", "30"))
 
 # Database Configuration (optimized for Raspberry Pi)
 DB_TIMEOUT = 30.0  # Database timeout in seconds (for slower SD card I/O)

--- a/database.py
+++ b/database.py
@@ -956,33 +956,51 @@ class DatabaseManager:
         'eco_rounds_won', 'eco_rounds_played', 'shots_hit', 'shots_fired',
     )
 
+    def _pms_insert_values(self, puuid: str, match_id: str, row: Dict[str, Any],
+                           stored_at: str) -> List[Any]:
+        """Build the VALUES list for one player_match_stats insert."""
+        values = [puuid, match_id, stored_at]
+        for field in self._PMS_SCALAR_FIELDS:
+            values.append(row.get(field))
+        for field in self._PMS_JSON_FIELDS:
+            values.append(json.dumps(row.get(field) or {}))
+        return values
+
+    @property
+    def _pms_insert_sql(self) -> str:
+        columns = ['puuid', 'match_id', 'stored_at'] + \
+            list(self._PMS_SCALAR_FIELDS) + list(self._PMS_JSON_FIELDS)
+        placeholders = ', '.join('?' for _ in columns)
+        return (f"INSERT OR REPLACE INTO player_match_stats ({', '.join(columns)}) "
+                f"VALUES ({placeholders})")
+
     def store_player_match_stats(self, puuid: str, match_id: str, row: Dict[str, Any]) -> bool:
         """Store computed per-match stats for one player. Idempotent by (puuid, match_id)."""
+        return self.store_player_match_stats_bulk([(puuid, match_id, row)]) == 1
+
+    def store_player_match_stats_bulk(self, entries: List[Tuple[str, str, Dict[str, Any]]]) -> int:
+        """Store many (puuid, match_id, row) stat lines in one transaction.
+
+        One connection/commit for the whole batch - much cheaper on SD-card
+        I/O than per-row writes. Returns the number of rows stored.
+        """
+        if not entries:
+            return 0
         with self._lock:
             conn = self._get_connection()
             try:
                 now = datetime.now(timezone.utc).isoformat()
-                columns = ['puuid', 'match_id', 'stored_at']
-                values = [puuid, match_id, now]
-                for field in self._PMS_SCALAR_FIELDS:
-                    columns.append(field)
-                    values.append(row.get(field))
-                for field in self._PMS_JSON_FIELDS:
-                    columns.append(field)
-                    values.append(json.dumps(row.get(field) or {}))
-
-                placeholders = ', '.join('?' for _ in columns)
-                conn.execute(
-                    f"INSERT OR REPLACE INTO player_match_stats ({', '.join(columns)}) "
-                    f"VALUES ({placeholders})",
-                    values
+                conn.executemany(
+                    self._pms_insert_sql,
+                    [self._pms_insert_values(puuid, match_id, row, now)
+                     for puuid, match_id, row in entries]
                 )
                 conn.commit()
-                return True
+                return len(entries)
             except Exception as e:
-                logging.error(f"Error storing per-match stats {puuid}/{match_id}: {e}")
+                logging.error(f"Error storing per-match stats batch ({len(entries)} rows): {e}")
                 conn.rollback()
-                return False
+                return 0
             finally:
                 conn.close()
 

--- a/database.py
+++ b/database.py
@@ -169,6 +169,51 @@ class DatabaseManager:
                     )
                 """)
                 
+                # Per-match, per-player computed stats. One row per (puuid, match),
+                # written once when a match is first processed (match data is
+                # immutable) and queried/aggregated for all stats features.
+                conn.execute("""
+                    CREATE TABLE IF NOT EXISTS player_match_stats (
+                        puuid TEXT NOT NULL,
+                        match_id TEXT NOT NULL,
+                        mode TEXT,                      -- normalized lowercase queue (e.g. 'competitive')
+                        map TEXT,
+                        agent TEXT,
+                        started_at TEXT,                -- ISO timestamp, used for ordering
+                        won INTEGER DEFAULT 0,
+                        rounds_played INTEGER DEFAULT 0,
+                        kills INTEGER DEFAULT 0,
+                        deaths INTEGER DEFAULT 0,
+                        assists INTEGER DEFAULT 0,
+                        headshots INTEGER DEFAULT 0,
+                        bodyshots INTEGER DEFAULT 0,
+                        legshots INTEGER DEFAULT 0,
+                        score INTEGER DEFAULT 0,
+                        damage_made INTEGER DEFAULT 0,
+                        damage_received INTEGER DEFAULT 0,
+                        kast_rounds INTEGER DEFAULT 0,
+                        first_bloods INTEGER DEFAULT 0,
+                        first_deaths INTEGER DEFAULT 0,
+                        multikills_2k INTEGER DEFAULT 0,
+                        multikills_3k INTEGER DEFAULT 0,
+                        multikills_4k INTEGER DEFAULT 0,
+                        multikills_5k INTEGER DEFAULT 0,
+                        rounds_survived INTEGER DEFAULT 0,
+                        pistol_rounds_won INTEGER DEFAULT 0,
+                        pistol_rounds_played INTEGER DEFAULT 0,
+                        eco_rounds_won INTEGER DEFAULT 0,
+                        eco_rounds_played INTEGER DEFAULT 0,
+                        shots_hit INTEGER DEFAULT 0,
+                        shots_fired INTEGER DEFAULT 0,
+                        clutches_attempted TEXT,        -- JSON {'1v2': n, ...}
+                        clutches_won TEXT,              -- JSON {'1v2': n, ...}
+                        weapon_kills TEXT,              -- JSON {weapon: kills}
+                        extra TEXT,                     -- JSON bag for future statlines
+                        stored_at TEXT NOT NULL,
+                        PRIMARY KEY (puuid, match_id)
+                    )
+                """)
+
                 conn.execute("""
                     CREATE TABLE IF NOT EXISTS henrik_accounts (
                         account_key TEXT PRIMARY KEY,  -- Format: username_tag or puuid
@@ -209,6 +254,8 @@ class DatabaseManager:
                 conn.execute("CREATE INDEX IF NOT EXISTS idx_henrik_accounts_puuid ON henrik_accounts(puuid)")
                 conn.execute("CREATE INDEX IF NOT EXISTS idx_henrik_accounts_last_accessed ON henrik_accounts(last_accessed)")
                 conn.execute("CREATE INDEX IF NOT EXISTS idx_henrik_accounts_data_size ON henrik_accounts(data_size)")
+                conn.execute("CREATE INDEX IF NOT EXISTS idx_player_match_stats_puuid_mode ON player_match_stats(puuid, mode, started_at DESC)")
+                conn.execute("CREATE INDEX IF NOT EXISTS idx_player_match_stats_match ON player_match_stats(match_id)")
                 
                 # Run migrations for existing installations
                 self._run_migrations(conn)
@@ -893,7 +940,108 @@ class DatabaseManager:
                 return False
             finally:
                 conn.close()
-    
+
+    # Per-match player stats (queryable, computed once per match)
+
+    # Columns persisted as JSON strings in player_match_stats
+    _PMS_JSON_FIELDS = ('clutches_attempted', 'clutches_won', 'weapon_kills', 'extra')
+    # Plain scalar columns in player_match_stats (everything except keys/JSON/stored_at)
+    _PMS_SCALAR_FIELDS = (
+        'mode', 'map', 'agent', 'started_at', 'won', 'rounds_played',
+        'kills', 'deaths', 'assists', 'headshots', 'bodyshots', 'legshots',
+        'score', 'damage_made', 'damage_received', 'kast_rounds',
+        'first_bloods', 'first_deaths',
+        'multikills_2k', 'multikills_3k', 'multikills_4k', 'multikills_5k',
+        'rounds_survived', 'pistol_rounds_won', 'pistol_rounds_played',
+        'eco_rounds_won', 'eco_rounds_played', 'shots_hit', 'shots_fired',
+    )
+
+    def store_player_match_stats(self, puuid: str, match_id: str, row: Dict[str, Any]) -> bool:
+        """Store computed per-match stats for one player. Idempotent by (puuid, match_id)."""
+        with self._lock:
+            conn = self._get_connection()
+            try:
+                now = datetime.now(timezone.utc).isoformat()
+                columns = ['puuid', 'match_id', 'stored_at']
+                values = [puuid, match_id, now]
+                for field in self._PMS_SCALAR_FIELDS:
+                    columns.append(field)
+                    values.append(row.get(field))
+                for field in self._PMS_JSON_FIELDS:
+                    columns.append(field)
+                    values.append(json.dumps(row.get(field) or {}))
+
+                placeholders = ', '.join('?' for _ in columns)
+                conn.execute(
+                    f"INSERT OR REPLACE INTO player_match_stats ({', '.join(columns)}) "
+                    f"VALUES ({placeholders})",
+                    values
+                )
+                conn.commit()
+                return True
+            except Exception as e:
+                logging.error(f"Error storing per-match stats {puuid}/{match_id}: {e}")
+                conn.rollback()
+                return False
+            finally:
+                conn.close()
+
+    def _pms_row_to_dict(self, row) -> Dict[str, Any]:
+        """Convert a player_match_stats DB row to a plain dict with parsed JSON fields."""
+        result = dict(row)
+        for field in self._PMS_JSON_FIELDS:
+            try:
+                result[field] = json.loads(result.get(field) or '{}')
+            except (TypeError, ValueError):
+                result[field] = {}
+        return result
+
+    def get_player_match_stats(self, puuid: str, mode: str = None,
+                               limit: int = 20) -> List[Dict[str, Any]]:
+        """Get a player's per-match stat rows, most recent first."""
+        with self._lock:
+            conn = self._get_connection()
+            try:
+                if mode:
+                    rows = conn.execute("""
+                        SELECT * FROM player_match_stats
+                        WHERE puuid = ? AND mode = ?
+                        ORDER BY started_at DESC LIMIT ?
+                    """, (puuid, mode.lower(), limit)).fetchall()
+                else:
+                    rows = conn.execute("""
+                        SELECT * FROM player_match_stats
+                        WHERE puuid = ?
+                        ORDER BY started_at DESC LIMIT ?
+                    """, (puuid, limit)).fetchall()
+                return [self._pms_row_to_dict(r) for r in rows]
+            except Exception as e:
+                logging.error(f"Error getting per-match stats for {puuid}: {e}")
+                return []
+            finally:
+                conn.close()
+
+    def get_player_match_stats_for_ids(self, puuid: str,
+                                       match_ids: List[str]) -> Dict[str, Dict[str, Any]]:
+        """Get per-match stat rows for specific match ids. Returns {match_id: row}."""
+        if not match_ids:
+            return {}
+        with self._lock:
+            conn = self._get_connection()
+            try:
+                placeholders = ', '.join('?' for _ in match_ids)
+                rows = conn.execute(
+                    f"SELECT * FROM player_match_stats "
+                    f"WHERE puuid = ? AND match_id IN ({placeholders})",
+                    [puuid] + list(match_ids)
+                ).fetchall()
+                return {r['match_id']: self._pms_row_to_dict(r) for r in rows}
+            except Exception as e:
+                logging.error(f"Error getting per-match stats by ids for {puuid}: {e}")
+                return {}
+            finally:
+                conn.close()
+
     def get_stored_account(self, username: str = None, tag: str = None, puuid: str = None) -> Optional[Dict[str, Any]]:
         """Get stored account data if it exists"""
         with self._lock:

--- a/match_tracker.py
+++ b/match_tracker.py
@@ -514,7 +514,10 @@ class MatchTracker:
         window_start = (start_dt - timedelta(minutes=10)) if start_dt else None
         window_end = end_dt + timedelta(minutes=5)
 
-        # Collect matches played in-window across all participant accounts
+        # Collect matches played in-window across all participant accounts.
+        # Discovery uses the lightweight competitive-updates endpoint (few KB);
+        # full details come from the permanent SQLite cache - the tracker has
+        # usually already stored them while the session was running.
         matches_by_id: Dict[str, Dict[str, Any]] = {}
         member_puuids: Dict[str, discord.Member] = {}
 
@@ -527,26 +530,31 @@ class MatchTracker:
                 if puuid:
                     member_puuids[puuid] = member
                 try:
-                    matches = await valorant_client.get_match_history(
-                        account['username'], account['tag'],
-                        size=5, mode='competitive'
+                    updates = await valorant_client.get_recent_competitive_updates(
+                        account['username'], account['tag'], puuid=puuid
                     )
                 except Exception as e:
                     log_error(f"fetching session matches for {account.get('username')}", e)
-                    matches = None
+                    updates = None
 
-                for match in matches or []:
-                    mid = match.get('metadata', {}).get('matchid')
+                for update in updates or []:
+                    mid = update.get('match_id')
                     if not mid or mid in matches_by_id:
                         continue
-                    started = parse_henrik_timestamp(match.get('metadata', {}).get('game_start', ''))
+                    started = update.get('started_at')
                     if started is None:
                         continue
                     if window_start and started < window_start:
                         continue
                     if started > window_end:
                         continue
-                    matches_by_id[mid] = match
+                    match = await valorant_client.get_match_details(mid)
+                    if match:
+                        matches_by_id[mid] = match
+
+        # Warm the per-match stat rows for everyone we fetched details for
+        for match in matches_by_id.values():
+            valorant_client.record_match_stats_for_players(match, list(member_puuids.keys()))
 
         # Aggregate per-player stats and W/L across in-window matches
         player_totals: Dict[int, Dict[str, Any]] = {}
@@ -1205,53 +1213,55 @@ class MatchTracker:
         if not members_to_check:
             return None
         
-        # Check the most recent match for each member
+        # Check the most recent matches for each member: discover match ids via
+        # the lightweight competitive-updates endpoint, then pull full details
+        # from the permanent SQLite cache (API only for genuinely new matches)
         for member in members_to_check:
             try:
                 # Get all linked accounts for this user, not just primary
                 all_accounts = valorant_client.get_all_linked_accounts(member.id)
                 if not all_accounts:
                     continue
-                
+
                 # Check matches for all linked accounts to get better coverage
                 for account in all_accounts:
-                    matches = await valorant_client.get_match_history(
+                    updates = await valorant_client.get_recent_competitive_updates(
                         account['username'],
                         account['tag'],
-                        size=5,  # Get more recent matches for better coverage
-                        mode='competitive',  # Only check competitive matches
-                        force_refresh=force_fresh  # Use the parameter to control freshness
+                        puuid=account.get('puuid'),
+                        force_refresh=force_fresh
                     )
-                    
-                    if not matches:
+
+                    if not updates:
                         continue
-                    
-                    # Check each match to find the most recent one with Discord members
-                    for match in matches:
-                        # Check if this match is already processed
-                        match_id = match.get('metadata', {}).get('matchid')
+
+                    # Check the most recent matches to find one with Discord members
+                    for update in updates[:5]:
+                        match_id = update.get('match_id')
                         if not match_id:
                             continue
-                        
+
+                        was_stored = database_manager.get_stored_match(match_id) is not None
+                        match = await valorant_client.get_match_details(match_id)
+                        if not match:
+                            continue
+
                         # Find Discord members in this match
                         discord_members_in_match = await self._find_discord_members_in_match(guild, match)
-                        
+
                         if len(discord_members_in_match) >= 1:
-                            # Check if we already have this match in our database
-                            stored_match = database_manager.get_stored_match(match_id)
-                            
                             embed = await self._create_match_embed(match, discord_members_in_match)
                             # Add manual check indicator
                             if embed:
-                                if stored_match:
+                                if was_stored:
                                     embed.set_footer(text="🔍 Manual match lookup (cached) • ShootyBot")
                                 else:
                                     embed.set_footer(text="🔍 Manual match lookup (fresh) • ShootyBot")
                             return embed
-                    
+
             except Exception as e:
                 log_error(f"in manual check for {member.display_name}", e)
-        
+
         return None
 
     async def _load_state_from_database(self) -> None:

--- a/match_tracker.py
+++ b/match_tracker.py
@@ -117,61 +117,72 @@ class MatchTracker:
             logging.debug(f"No active stack members with linked Valorant accounts in {guild.name}")
     
     async def _check_recent_matches(self, guild: discord.Guild, members: List[discord.Member]) -> None:
-        """Check recent matches for specific members"""
+        """Check recent matches for specific members.
+
+        Polls the lightweight competitive-updates endpoint (a few KB) to detect
+        new matches; full match details (multi-MB) are fetched at most once per
+        new match id and permanently cached in SQLite.
+        """
         server_matches = self.recent_matches.setdefault(guild.id, {})
         cutoff_time = datetime.now(timezone.utc) - timedelta(hours=self.MATCH_CUTOFF_HOURS)
-        
+
         for member in members:
             try:
                 primary_account = valorant_client.get_linked_account(member.id)
                 if not primary_account:
                     continue
-                
-                # Get recent matches (competitive only)
-                matches = await valorant_client.get_match_history(
+
+                # Cheap poll: recent competitive match ids + timestamps only
+                updates = await valorant_client.get_recent_competitive_updates(
                     primary_account['username'],
                     primary_account['tag'],
-                    size=1,  # Only check most recent match for polling efficiency
-                    mode='competitive'  # Only track competitive matches
+                    puuid=primary_account.get('puuid')
                 )
-                
-                if not matches:
+
+                if not updates:
                     continue
-                
-                # Check if this member has a new most recent match
-                latest_match = matches[0]  # Most recent match
-                latest_match_id = latest_match.get('metadata', {}).get('matchid')
-                
+
+                latest_update = updates[0]  # Most recent match
+                latest_match_id = latest_update.get('match_id')
+
                 if not latest_match_id:
                     continue
-                
+
                 # Check if this is a new match for this member
                 last_known_match = self.tracked_members.get(member.id, {}).get('last_match_id')
-                
+
                 if last_known_match != latest_match_id:
                     # Update the last known match for this member
                     self.tracked_members[member.id]['last_match_id'] = latest_match_id
-                    
+
                     # Skip if we've already processed this match globally
                     if latest_match_id in server_matches:
                         continue
-                    
-                    # Skip old matches
-                    started_at = latest_match.get('metadata', {}).get('game_start', '')
-                    match_time = parse_henrik_timestamp(started_at)
-                    if match_time:
-                        if match_time < cutoff_time:
-                            continue
-                    else:
+
+                    # Skip old matches (before paying for the full details)
+                    match_time = latest_update.get('started_at')
+                    if not match_time or match_time < cutoff_time:
                         continue
-                    
+
+                    # New recent match: fetch full details once (SQLite-cached)
+                    latest_match = await valorant_client.get_match_details(latest_match_id)
+                    if not latest_match:
+                        continue
+
                     # Skip if match is not completed
                     if not latest_match.get('metadata', {}).get('game_length', 0):
                         continue
-                    
+
                     # Find all Discord members in this match
                     discord_members_in_match = await self._find_discord_members_in_match(guild, latest_match)
-                    
+
+                    # Persist per-match stat rows for every linked player in the
+                    # match, so stats commands have warm data without API calls
+                    valorant_client.record_match_stats_for_players(
+                        latest_match,
+                        [dm['account'].get('puuid') for dm in discord_members_in_match]
+                    )
+
                     # Only process if minimum Discord members were in the match
                     if len(discord_members_in_match) >= self.MIN_DISCORD_MEMBERS:
                         server_matches[latest_match_id] = {
@@ -179,16 +190,16 @@ class MatchTracker:
                             'members': discord_members_in_match,
                             'match_data': latest_match
                         }
-                        
+
                         # Send match results to appropriate channel
                         await self._send_match_results(guild, latest_match, discord_members_in_match)
-                        
+
                         # Update stack activity tracking
                         await self._update_stack_activity(guild, discord_members_in_match, latest_match)
-                        
+
             except Exception as e:
                 log_error(f"checking matches for {member.display_name}", e)
-        
+
         # Clean up old matches
         for match_id in list(server_matches.keys()):
             if server_matches[match_id]['timestamp'] < cutoff_time:
@@ -463,7 +474,7 @@ class MatchTracker:
                 continue
 
             try:
-                mmr = await valorant_client.get_mmr(username, tag)
+                mmr = await valorant_client.get_mmr(username, tag, puuid=account.get('puuid'))
             except Exception as e:
                 log_error(f"fetching rank for {username}#{tag}", e)
                 mmr = None
@@ -637,7 +648,8 @@ class MatchTracker:
             if not account:
                 continue
             try:
-                mmr = await valorant_client.get_mmr(account['username'], account['tag'])
+                mmr = await valorant_client.get_mmr(account['username'], account['tag'],
+                                                    puuid=account.get('puuid'))
             except Exception:
                 mmr = None
             if mmr and mmr.get('tier'):

--- a/tests/unit/commands/test_valorant_commands.py
+++ b/tests/unit/commands/test_valorant_commands.py
@@ -49,30 +49,8 @@ class TestValorantCommands(unittest.IsolatedAsyncioTestCase):
             'puuid': 'test-puuid-123'
         }
         
-        # Mock match history
-        mock_valorant_client.get_match_history = AsyncMock(return_value=[{
-            'metadata': {'matchid': '123', 'map': 'Ascent'},
-            'players': {'all_players': [{
-                'puuid': 'test-puuid-123',
-                'stats': {
-                    'kills': 20,
-                    'deaths': 10,
-                    'assists': 5,
-                    'score': 5000,
-                    'bodyshots': 30,
-                    'headshots': 10,
-                    'damage_made': 3000,
-                    'damage_received': 2000
-                },
-                'character': 'Jett',
-                'team': 'Red'
-            }]},
-            'rounds': [{'winning_team': 'Red'}] * 13 + [{'winning_team': 'Blue'}] * 5,
-            'teams': {'red': {'has_won': True}}
-        }])
-        
-        # Mock stats calculation
-        mock_valorant_client.calculate_player_stats.return_value = {
+        # Mock aggregated stats from the incremental stats pipeline
+        mock_valorant_client.get_player_stats = AsyncMock(return_value={
             'total_matches': 1,
             'acs': 250,
             'kd_ratio': 2.0,
@@ -111,8 +89,8 @@ class TestValorantCommands(unittest.IsolatedAsyncioTestCase):
                 'rounds_played': 18,
                 'agent': 'Jett'
             }]
-        }
-        
+        })
+
         # Execute command - call the callback directly
         await self.cog.detailed_valorant_stats.callback(self.cog, self.ctx)
         
@@ -150,11 +128,8 @@ class TestValorantCommands(unittest.IsolatedAsyncioTestCase):
             'puuid': 'test-puuid-123'
         }
         
-        # Mock match history
-        mock_valorant_client.get_match_history = AsyncMock(return_value=[{'fake': 'match'}])
-        
-        # Mock stats calculation without performance_ratings
-        mock_valorant_client.calculate_player_stats.return_value = {
+        # Mock aggregated stats without performance_ratings
+        mock_valorant_client.get_player_stats = AsyncMock(return_value={
             'total_matches': 1,
             'acs': 200,
             'kd_ratio': 1.5,
@@ -180,8 +155,8 @@ class TestValorantCommands(unittest.IsolatedAsyncioTestCase):
             'max_win_streak': 1,
             'first_blood_rate': 25.0,
             'clutch_success_rate': 50.0
-        }
-        
+        })
+
         # Execute command - should not error even without performance_ratings
         await self.cog.detailed_valorant_stats.callback(self.cog, self.ctx)
         
@@ -266,11 +241,8 @@ class TestValorantCommands(unittest.IsolatedAsyncioTestCase):
         }
         mock_valorant_client.get_linked_account.side_effect = lambda uid: accounts.get(uid)
         mock_valorant_client.get_all_linked_accounts.side_effect = lambda uid: [accounts[uid]] if uid in accounts else []
-        mock_valorant_client.get_match_history = AsyncMock(
-            side_effect=lambda u, t, **kw: [{'puuid': 'pa' if u == 'Alice' else 'pb'}]
-        )
-        mock_valorant_client.calculate_player_stats.side_effect = (
-            lambda matches, puuid, **kw: stats[matches[0]['puuid']]
+        mock_valorant_client.get_player_stats = AsyncMock(
+            side_effect=lambda u, t, **kw: stats['pa' if u == 'Alice' else 'pb']
         )
         mock_valorant_client.get_mmr = AsyncMock(return_value=None)
 
@@ -303,18 +275,15 @@ class TestValorantCommands(unittest.IsolatedAsyncioTestCase):
             2: {'username': 'Bob', 'tag': 'NA1', 'puuid': 'pb'},
         }
         mock_valorant_client.get_linked_account.side_effect = lambda uid: accounts.get(uid)
-        mock_valorant_client.get_match_history = AsyncMock(
-            side_effect=lambda u, t, **kw: [{'puuid': accounts[1]['puuid'] if u == 'Alice' else accounts[2]['puuid']}]
-        )
-        mock_valorant_client.calculate_player_stats.side_effect = (
-            lambda matches, puuid, **kw: {'total_matches': 5, 'puuid': matches[0]['puuid']}
+        mock_valorant_client.get_player_stats = AsyncMock(
+            side_effect=lambda u, t, **kw: {'total_matches': 5, 'puuid': accounts[1]['puuid'] if u == 'Alice' else accounts[2]['puuid']}
         )
 
         results = await self.cog._gather_member_stats(guild)
 
         # Only Alice and Bob qualify (bot and unlinked excluded)
         self.assertEqual({r['member'].display_name for r in results}, {'Alice', 'Bob'})
-        self.assertEqual(mock_valorant_client.get_match_history.await_count, 2)
+        self.assertEqual(mock_valorant_client.get_player_stats.await_count, 2)
 
     @patch('commands.valorant_commands.valorant_client')
     async def test_weapon_leaderboard_success(self, mock_valorant_client):
@@ -333,11 +302,8 @@ class TestValorantCommands(unittest.IsolatedAsyncioTestCase):
             'pb': {'total_matches': 5, 'weapon_kills': {'Vandal': 60, 'Sheriff': 3}},
         }
         mock_valorant_client.get_linked_account.side_effect = lambda uid: accounts.get(uid)
-        mock_valorant_client.get_match_history = AsyncMock(
-            side_effect=lambda u, t, **kw: [{'puuid': accounts[1]['puuid'] if u == 'Alice' else accounts[2]['puuid']}]
-        )
-        mock_valorant_client.calculate_player_stats.side_effect = (
-            lambda matches, puuid, **kw: weapon_stats[matches[0]['puuid']]
+        mock_valorant_client.get_player_stats = AsyncMock(
+            side_effect=lambda u, t, **kw: weapon_stats[accounts[1]['puuid'] if u == 'Alice' else accounts[2]['puuid']]
         )
 
         await self.cog.weapon_leaderboard.callback(self.cog, self.ctx, weapon='vandal')
@@ -357,7 +323,7 @@ class TestValorantCommands(unittest.IsolatedAsyncioTestCase):
         await self.cog.weapon_leaderboard.callback(self.cog, self.ctx, weapon='banana')
 
         self.cog.send_error_embed.assert_awaited_once()
-        mock_valorant_client.get_match_history.assert_not_called()
+        mock_valorant_client.get_player_stats.assert_not_called()
 
     @patch('commands.valorant_commands.valorant_client')
     async def test_weapon_leaderboard_no_kills(self, mock_valorant_client):
@@ -367,10 +333,9 @@ class TestValorantCommands(unittest.IsolatedAsyncioTestCase):
         mock_valorant_client.get_linked_account.side_effect = (
             lambda uid: {'username': 'Alice', 'tag': 'NA1', 'puuid': 'pa'} if uid == 1 else None
         )
-        mock_valorant_client.get_match_history = AsyncMock(return_value=[{'puuid': 'pa'}])
-        mock_valorant_client.calculate_player_stats.return_value = {
+        mock_valorant_client.get_player_stats = AsyncMock(return_value={
             'total_matches': 5, 'weapon_kills': {'Phantom': 10}
-        }
+        })
 
         await self.cog.weapon_leaderboard.callback(self.cog, self.ctx, weapon='Operator')
 

--- a/tests/unit/test_henrik_efficiency.py
+++ b/tests/unit/test_henrik_efficiency.py
@@ -319,13 +319,15 @@ class TestGetPlayerStats:
         with patch('valorant_client.database_manager.get_player_match_stats_for_ids',
                    return_value={}), \
              patch('valorant_client.database_manager.get_stored_match', return_value=None), \
-             patch('valorant_client.database_manager.store_player_match_stats') as mock_store_row:
+             patch('valorant_client.database_manager.store_player_match_stats_bulk') as mock_store_rows:
             stats = await client.get_player_stats('User', 'TAG', size=5)
 
         assert stats['total_matches'] == 1
         client.get_match_details.assert_called_once_with('match-1')
         client.get_match_history.assert_not_called()  # below bulk threshold
-        mock_store_row.assert_called_once()
+        # the new row is persisted in the flush batch
+        (entries,) = mock_store_rows.call_args.args
+        assert [(e[0], e[1]) for e in entries] == [('player-1', 'match-1')]
 
     @pytest.mark.asyncio
     async def test_many_missing_matches_use_one_bulk_call(self, client):
@@ -341,7 +343,7 @@ class TestGetPlayerStats:
                    return_value={}), \
              patch('valorant_client.database_manager.get_stored_match', return_value=None), \
              patch('valorant_client.database_manager.store_match'), \
-             patch('valorant_client.database_manager.store_player_match_stats'):
+             patch('valorant_client.database_manager.store_player_match_stats_bulk'):
             stats = await client.get_player_stats('User', 'TAG', size=5)
 
         assert stats['total_matches'] == 5
@@ -357,7 +359,7 @@ class TestGetPlayerStats:
         client.get_match_history = AsyncMock(return_value=matches)
 
         with patch('valorant_client.database_manager.store_match'), \
-             patch('valorant_client.database_manager.store_player_match_stats'):
+             patch('valorant_client.database_manager.store_player_match_stats_bulk'):
             stats = await client.get_player_stats('User', 'TAG', size=20)
 
         assert stats['total_matches'] == 1
@@ -377,18 +379,19 @@ class TestGetPlayerStats:
 class TestRecordMatchStats:
     def test_records_rows_for_each_player(self, client):
         match = build_full_match()
-        with patch('valorant_client.database_manager.store_player_match_stats',
-                   return_value=True) as mock_store:
+        with patch('valorant_client.database_manager.store_player_match_stats_bulk',
+                   side_effect=len) as mock_store:
             count = client.record_match_stats_for_players(match, ['player-1', 'enemy-1', None])
 
         assert count == 2
-        stored_puuids = {call.args[0] for call in mock_store.call_args_list}
-        assert stored_puuids == {'player-1', 'enemy-1'}
+        # all rows for the match go to the database in one batch
+        (entries,) = mock_store.call_args.args
+        assert {e[0] for e in entries} == {'player-1', 'enemy-1'}
 
     def test_no_match_id_stores_nothing(self, client):
         match = build_full_match()
         del match['metadata']['matchid']
-        with patch('valorant_client.database_manager.store_player_match_stats') as mock_store:
+        with patch('valorant_client.database_manager.store_player_match_stats_bulk') as mock_store:
             assert client.record_match_stats_for_players(match, ['player-1']) == 0
         mock_store.assert_not_called()
 

--- a/tests/unit/test_henrik_efficiency.py
+++ b/tests/unit/test_henrik_efficiency.py
@@ -1,0 +1,522 @@
+"""Tests for the efficient Henrik API usage architecture:
+
+- lightweight endpoints (stored-matches, mmr-history) for discovery/polling
+- permanent SQLite caching of immutable match details
+- per-match stat rows computed once and aggregated for stats commands
+- client-level behavior: no retries on 4xx, rate-limit header tracking
+"""
+
+import os
+import sys
+import tempfile
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../..')))
+
+from api_clients import APIResponse
+from database import DatabaseManager
+from valorant_client import ValorantClient
+
+
+def build_full_match(match_id='match-1', player_puuid='player-1', game_start=1700000000):
+    """A minimal-but-complete competitive match with round data."""
+    return {
+        "metadata": {
+            "matchid": match_id,
+            "map": "Ascent",
+            "mode": "Competitive",
+            "mode_id": "competitive",
+            "queue": "competitive",
+            "rounds_played": 2,
+            "game_start": game_start,
+            "game_length": 1800,
+        },
+        "is_available": True,
+        "players": {
+            "all_players": [
+                {
+                    "puuid": player_puuid,
+                    "team": "Red",
+                    "character": "Jett",
+                    "stats": {"kills": 3, "deaths": 1, "assists": 0,
+                              "headshots": 2, "bodyshots": 1, "legshots": 0, "score": 600},
+                    "damage_made": 400,
+                    "damage_received": 200,
+                },
+                {
+                    "puuid": "enemy-1",
+                    "team": "Blue",
+                    "character": "Sage",
+                    "stats": {"kills": 1, "deaths": 3, "assists": 0,
+                              "headshots": 0, "bodyshots": 3, "legshots": 0, "score": 150},
+                    "damage_made": 150,
+                    "damage_received": 400,
+                },
+            ]
+        },
+        "teams": {"red": {"has_won": True}, "blue": {"has_won": False}},
+        "rounds": [
+            {
+                "winning_team": "Red",
+                "player_stats": [
+                    {
+                        "player_puuid": player_puuid,
+                        "kills": 2,
+                        "kill_events": [
+                            {"victim_puuid": "enemy-1", "kill_time_in_round": 1000,
+                             "damage_weapon_name": "Vandal", "assistants": []},
+                            {"victim_puuid": "enemy-1", "kill_time_in_round": 2000,
+                             "damage_weapon_assets": {"display_name": "Phantom"}, "assistants": []},
+                        ],
+                        "economy": {"loadout_value": 800},
+                    }
+                ],
+            },
+            {
+                "winning_team": "Red",
+                "player_stats": [
+                    {
+                        "player_puuid": player_puuid,
+                        "kills": 1,
+                        "kill_events": [
+                            {"victim_puuid": "enemy-1", "kill_time_in_round": 1500,
+                             "damage_weapon_name": "Vandal", "assistants": []},
+                        ],
+                        "economy": {"loadout_value": 4000},
+                    }
+                ],
+            },
+        ],
+    }
+
+
+@pytest.fixture
+def client():
+    with patch('valorant_client.HENRIK_API_KEY', ''):
+        return ValorantClient()
+
+
+@pytest.fixture
+def temp_db():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        yield DatabaseManager(db_path=os.path.join(tmpdir, 'test.db'))
+
+
+# ---------------------------------------------------------------------------
+# Per-match stat rows + aggregation
+# ---------------------------------------------------------------------------
+
+class TestMatchStatsRows:
+    def test_build_match_stats_row_basics(self, client):
+        row = client.build_match_stats_row(build_full_match(), 'player-1')
+
+        assert row['kills'] == 3
+        assert row['deaths'] == 1
+        assert row['won'] == 1
+        assert row['mode'] == 'competitive'
+        assert row['map'] == 'Ascent'
+        assert row['agent'] == 'Jett'
+        assert row['rounds_played'] == 2
+        assert row['multikills_2k'] == 1
+        assert row['first_bloods'] == 2  # first chronological kill both rounds
+        assert row['weapon_kills'] == {'Vandal': 2, 'Phantom': 1}
+        assert row['kast_rounds'] == 2
+        assert row['pistol_rounds_played'] == 1  # round 0 only (2-round match)
+        assert row['pistol_rounds_won'] == 1
+        assert row['eco_rounds_played'] == 1  # loadout 800 in round 0
+        assert row['started_at'] is not None
+
+    def test_build_row_returns_none_for_absent_player(self, client):
+        assert client.build_match_stats_row(build_full_match(), 'nobody') is None
+
+    def test_aggregate_matches_calculate_player_stats(self, client):
+        """Aggregating rows must equal the legacy full-match calculation."""
+        matches = [build_full_match('m1'), build_full_match('m2')]
+
+        legacy = client.calculate_player_stats(matches, 'player-1')
+        rows = [client.build_match_stats_row(m, 'player-1') for m in matches]
+        aggregated = client.aggregate_match_rows(rows)
+
+        assert aggregated == legacy
+        assert aggregated['total_matches'] == 2
+        assert aggregated['total_kills'] == 6
+        assert aggregated['weapon_kills'] == {'Vandal': 4, 'Phantom': 2}
+        assert aggregated['win_rate'] == 100.0
+        assert aggregated['kast_percentage'] == 100.0
+
+    def test_aggregate_empty_rows(self, client):
+        assert client.aggregate_match_rows([]) == {}
+
+
+# ---------------------------------------------------------------------------
+# Database round-trip for per-match rows
+# ---------------------------------------------------------------------------
+
+class TestPlayerMatchStatsStorage:
+    def test_round_trip_preserves_aggregation(self, client, temp_db):
+        match = build_full_match()
+        row = client.build_match_stats_row(match, 'player-1')
+
+        assert temp_db.store_player_match_stats('player-1', 'match-1', row)
+
+        fetched = temp_db.get_player_match_stats('player-1', mode='competitive', limit=5)
+        assert len(fetched) == 1
+
+        # Aggregating the DB row gives the same stats as the in-memory row
+        from_db = client.aggregate_match_rows(fetched)
+        from_memory = client.aggregate_match_rows([row])
+        assert from_db == from_memory
+
+    def test_get_for_ids(self, client, temp_db):
+        row = client.build_match_stats_row(build_full_match(), 'player-1')
+        temp_db.store_player_match_stats('player-1', 'match-1', row)
+
+        found = temp_db.get_player_match_stats_for_ids('player-1', ['match-1', 'match-2'])
+        assert set(found.keys()) == {'match-1'}
+        assert found['match-1']['kills'] == 3
+        assert found['match-1']['weapon_kills'] == {'Vandal': 2, 'Phantom': 1}
+
+    def test_store_is_idempotent(self, client, temp_db):
+        row = client.build_match_stats_row(build_full_match(), 'player-1')
+        temp_db.store_player_match_stats('player-1', 'match-1', row)
+        temp_db.store_player_match_stats('player-1', 'match-1', row)
+        assert len(temp_db.get_player_match_stats('player-1')) == 1
+
+    def test_mode_filtering_and_ordering(self, client, temp_db):
+        older = build_full_match('m-old', game_start=1700000000)
+        newer = build_full_match('m-new', game_start=1700009999)
+        temp_db.store_player_match_stats('player-1', 'm-old',
+                                         client.build_match_stats_row(older, 'player-1'))
+        temp_db.store_player_match_stats('player-1', 'm-new',
+                                         client.build_match_stats_row(newer, 'player-1'))
+
+        rows = temp_db.get_player_match_stats('player-1', mode='competitive')
+        assert [r['match_id'] for r in rows] == ['m-new', 'm-old']
+        assert temp_db.get_player_match_stats('player-1', mode='unrated') == []
+
+
+# ---------------------------------------------------------------------------
+# Lightweight endpoints
+# ---------------------------------------------------------------------------
+
+class TestLightweightEndpoints:
+    @pytest.mark.asyncio
+    async def test_stored_matches_light_normalization(self, client):
+        payload = {'data': [
+            {'meta': {'id': 'm1', 'map': {'id': 'x', 'name': 'Ascent'},
+                      'mode': 'Competitive', 'started_at': '2024-01-02T00:00:00Z'},
+             'stats': {'kills': 10}, 'teams': {'red': 13, 'blue': 8}},
+            {'meta': {'id': 'm2', 'map': {'name': 'Bind'},
+                      'mode': 'Competitive', 'started_at': '2024-01-03T00:00:00Z'},
+             'stats': {'kills': 5}, 'teams': {}},
+        ]}
+        client.get = AsyncMock(return_value=APIResponse(data=payload, status_code=200))
+
+        result = await client.get_stored_matches_light('User', 'TAG', puuid='abc', size=5,
+                                                       mode='competitive')
+
+        # by-puuid endpoint used, newest first
+        endpoint = client.get.call_args.args[0]
+        assert endpoint == 'v1/by-puuid/stored-matches/na/abc'
+        assert client.get.call_args.kwargs['params'] == {'size': 5, 'mode': 'competitive'}
+        assert [m['match_id'] for m in result] == ['m2', 'm1']
+        assert result[0]['map'] == 'Bind'
+
+    @pytest.mark.asyncio
+    async def test_stored_matches_light_failure_returns_none(self, client):
+        client.get = AsyncMock(return_value=APIResponse(data={}, status_code=404))
+        assert await client.get_stored_matches_light('User', 'TAG') is None
+
+    @pytest.mark.asyncio
+    async def test_recent_competitive_updates_normalization(self, client):
+        payload = {'data': [
+            {'match_id': 'm-new', 'mmr_change_to_last_game': 18, 'date_raw': 1700009999},
+            {'match_id': 'm-old', 'mmr_change_to_last_game': -12, 'date_raw': 1700000000},
+        ]}
+        client.get = AsyncMock(return_value=APIResponse(data=payload, status_code=200))
+
+        result = await client.get_recent_competitive_updates('User', 'TAG', puuid='abc')
+
+        endpoint = client.get.call_args.args[0]
+        assert endpoint == 'v1/by-puuid/mmr-history/na/abc'
+        assert result[0]['match_id'] == 'm-new'
+        assert result[0]['rr_change'] == 18
+        assert result[0]['started_at'] is not None
+
+    @pytest.mark.asyncio
+    async def test_manual_link_placeholder_puuid_not_used(self, client):
+        """manual_<name>_<tag> placeholder puuids must not hit by-puuid endpoints."""
+        client.get = AsyncMock(return_value=APIResponse(data={'data': []}, status_code=200))
+        await client.get_recent_competitive_updates('User', 'TAG', puuid='manual_User_TAG')
+        endpoint = client.get.call_args.args[0]
+        assert endpoint == 'v1/mmr-history/na/User/TAG'
+
+
+# ---------------------------------------------------------------------------
+# Permanent match details cache
+# ---------------------------------------------------------------------------
+
+class TestMatchDetailsCache:
+    @pytest.mark.asyncio
+    async def test_db_hit_skips_api(self, client):
+        stored = build_full_match()
+        client.get = AsyncMock()
+        with patch('valorant_client.database_manager.get_stored_match', return_value=stored):
+            result = await client.get_match_details('match-1')
+
+        assert result == stored
+        client.get.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_db_miss_fetches_and_stores(self, client):
+        match = build_full_match()
+        client.get = AsyncMock(return_value=APIResponse(data={'data': match}, status_code=200))
+        with patch('valorant_client.database_manager.get_stored_match', return_value=None), \
+             patch('valorant_client.database_manager.store_match') as mock_store:
+            result = await client.get_match_details('match-1')
+
+        assert result == match
+        client.get.assert_called_once_with('v2/match/match-1', use_cache=False)
+        mock_store.assert_called_once_with('match-1', match)
+
+
+# ---------------------------------------------------------------------------
+# get_player_stats orchestration
+# ---------------------------------------------------------------------------
+
+class TestGetPlayerStats:
+    @pytest.mark.asyncio
+    async def test_warm_path_makes_no_heavy_calls(self, client):
+        """When all discovered matches already have rows, no match data is fetched."""
+        match = build_full_match()
+        row = client.build_match_stats_row(match, 'player-1')
+
+        client.get_account_info = AsyncMock(return_value={'puuid': 'player-1'})
+        client._discover_recent_match_ids = AsyncMock(return_value=['match-1'])
+        client.get_match_history = AsyncMock()
+        client.get_match_details = AsyncMock()
+
+        with patch('valorant_client.database_manager.get_player_match_stats_for_ids',
+                   return_value={'match-1': row}):
+            stats = await client.get_player_stats('User', 'TAG', size=5)
+
+        assert stats['total_matches'] == 1
+        assert stats['total_kills'] == 3
+        client.get_match_history.assert_not_called()
+        client.get_match_details.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_missing_match_fetched_individually_and_persisted(self, client):
+        match = build_full_match()
+
+        client.get_account_info = AsyncMock(return_value={'puuid': 'player-1'})
+        client._discover_recent_match_ids = AsyncMock(return_value=['match-1'])
+        client.get_match_history = AsyncMock()
+        client.get_match_details = AsyncMock(return_value=match)
+
+        with patch('valorant_client.database_manager.get_player_match_stats_for_ids',
+                   return_value={}), \
+             patch('valorant_client.database_manager.get_stored_match', return_value=None), \
+             patch('valorant_client.database_manager.store_player_match_stats') as mock_store_row:
+            stats = await client.get_player_stats('User', 'TAG', size=5)
+
+        assert stats['total_matches'] == 1
+        client.get_match_details.assert_called_once_with('match-1')
+        client.get_match_history.assert_not_called()  # below bulk threshold
+        mock_store_row.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_many_missing_matches_use_one_bulk_call(self, client):
+        ids = [f'match-{i}' for i in range(5)]
+        matches = [build_full_match(mid) for mid in ids]
+
+        client.get_account_info = AsyncMock(return_value={'puuid': 'player-1'})
+        client._discover_recent_match_ids = AsyncMock(return_value=ids)
+        client.get_match_history = AsyncMock(return_value=matches)
+        client.get_match_details = AsyncMock()
+
+        with patch('valorant_client.database_manager.get_player_match_stats_for_ids',
+                   return_value={}), \
+             patch('valorant_client.database_manager.get_stored_match', return_value=None), \
+             patch('valorant_client.database_manager.store_match'), \
+             patch('valorant_client.database_manager.store_player_match_stats'):
+            stats = await client.get_player_stats('User', 'TAG', size=5)
+
+        assert stats['total_matches'] == 5
+        client.get_match_history.assert_awaited_once()
+        client.get_match_details.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_fallback_to_matchlist_when_discovery_fails(self, client):
+        matches = [build_full_match('m1')]
+
+        client.get_account_info = AsyncMock(return_value={'puuid': 'player-1'})
+        client._discover_recent_match_ids = AsyncMock(return_value=[])
+        client.get_match_history = AsyncMock(return_value=matches)
+
+        with patch('valorant_client.database_manager.store_match'), \
+             patch('valorant_client.database_manager.store_player_match_stats'):
+            stats = await client.get_player_stats('User', 'TAG', size=20)
+
+        assert stats['total_matches'] == 1
+        # size must be clamped to the matchlist API max
+        assert client.get_match_history.call_args.kwargs['size'] <= ValorantClient.MATCH_LIST_MAX_SIZE
+
+    @pytest.mark.asyncio
+    async def test_returns_none_without_account(self, client):
+        client.get_account_info = AsyncMock(return_value=None)
+        assert await client.get_player_stats('User', 'TAG') is None
+
+
+# ---------------------------------------------------------------------------
+# Tracker integration: record rows for everyone in a fetched match
+# ---------------------------------------------------------------------------
+
+class TestRecordMatchStats:
+    def test_records_rows_for_each_player(self, client):
+        match = build_full_match()
+        with patch('valorant_client.database_manager.store_player_match_stats',
+                   return_value=True) as mock_store:
+            count = client.record_match_stats_for_players(match, ['player-1', 'enemy-1', None])
+
+        assert count == 2
+        stored_puuids = {call.args[0] for call in mock_store.call_args_list}
+        assert stored_puuids == {'player-1', 'enemy-1'}
+
+    def test_no_match_id_stores_nothing(self, client):
+        match = build_full_match()
+        del match['metadata']['matchid']
+        with patch('valorant_client.database_manager.store_player_match_stats') as mock_store:
+            assert client.record_match_stats_for_players(match, ['player-1']) == 0
+        mock_store.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Match tracker polling: lightweight detection, heavy fetch only on new match
+# ---------------------------------------------------------------------------
+
+class TestTrackerPolling:
+    def _make_member(self, user_id=1, name='Player'):
+        import discord
+        member = MagicMock(spec=discord.Member)
+        member.id = user_id
+        member.display_name = name
+        member.bot = False
+        return member
+
+    @pytest.mark.asyncio
+    async def test_new_match_triggers_single_detail_fetch(self):
+        import discord
+        from datetime import datetime, timezone
+        from match_tracker import MatchTracker
+
+        bot = MagicMock(spec=discord.Client)
+        tracker = MatchTracker(bot)
+        guild = MagicMock(spec=discord.Guild)
+        guild.id = 1
+
+        member = self._make_member()
+        match = build_full_match('new-match')
+        account = {'username': 'User', 'tag': 'TAG', 'puuid': 'player-1'}
+
+        with patch('match_tracker.valorant_client') as mock_client:
+            mock_client.get_linked_account.return_value = account
+            mock_client.get_recent_competitive_updates = AsyncMock(return_value=[
+                {'match_id': 'new-match', 'started_at': datetime.now(timezone.utc),
+                 'rr_change': 20}
+            ])
+            mock_client.get_match_details = AsyncMock(return_value=match)
+            mock_client.record_match_stats_for_players = MagicMock(return_value=1)
+
+            tracker.tracked_members[member.id] = {'last_checked': None, 'last_match_id': None}
+            discord_members = [
+                {'member': member, 'account': account,
+                 'player_data': match['players']['all_players'][0]},
+                {'member': self._make_member(2, 'Mate'), 'account': {'puuid': 'enemy-1'},
+                 'player_data': match['players']['all_players'][1]},
+            ]
+            tracker._find_discord_members_in_match = AsyncMock(return_value=discord_members)
+            tracker._send_match_results = AsyncMock()
+            tracker._update_stack_activity = AsyncMock()
+
+            await tracker._check_recent_matches(guild, [member])
+
+            # Heavy match details fetched exactly once, results announced,
+            # and stat rows persisted for every linked player in the match
+            mock_client.get_match_details.assert_awaited_once_with('new-match')
+            tracker._send_match_results.assert_awaited_once()
+            mock_client.record_match_stats_for_players.assert_called_once()
+
+            # Second poll with the same latest match: no further heavy fetches
+            await tracker._check_recent_matches(guild, [member])
+            mock_client.get_match_details.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_no_updates_means_no_fetches(self):
+        import discord
+        from match_tracker import MatchTracker
+
+        bot = MagicMock(spec=discord.Client)
+        tracker = MatchTracker(bot)
+        guild = MagicMock(spec=discord.Guild)
+        guild.id = 1
+        member = self._make_member()
+
+        with patch('match_tracker.valorant_client') as mock_client:
+            mock_client.get_linked_account.return_value = {
+                'username': 'User', 'tag': 'TAG', 'puuid': 'player-1'}
+            mock_client.get_recent_competitive_updates = AsyncMock(return_value=[])
+            mock_client.get_match_details = AsyncMock()
+
+            tracker.tracked_members[member.id] = {'last_checked': None, 'last_match_id': None}
+            await tracker._check_recent_matches(guild, [member])
+
+            mock_client.get_match_details.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Base client behavior
+# ---------------------------------------------------------------------------
+
+class TestClientErrorHandling:
+    def test_retry_after_parsing(self, client):
+        assert client._get_retry_after_seconds({'Retry-After': '5'}) == 5
+        assert client._get_retry_after_seconds({'x-ratelimit-reset': '12'}) == 12
+        # Epoch-style values are capped instead of stalling for hours
+        assert client._get_retry_after_seconds({'retry-after': '1700000000'}) == 60
+        assert client._get_retry_after_seconds({}) == 30
+
+    def test_rate_limit_header_tracking(self, client):
+        info = client._parse_rate_limit_headers({
+            'X-RateLimit-Remaining': '0',
+            'X-RateLimit-Reset': '15',
+        })
+        assert info is not None
+        assert client._server_requests_remaining == 0
+        assert client._server_limit_resets_at is not None
+
+    @pytest.mark.asyncio
+    async def test_4xx_response_not_retried(self, client):
+        """A 404 must return immediately as a response, not raise/retry."""
+        fake_response = MagicMock()
+        fake_response.status = 404
+        fake_response.headers = {'content-type': 'application/json'}
+        fake_response.json = AsyncMock(return_value={'message': 'not found'})
+
+        request_cm = MagicMock()
+        request_cm.__aenter__ = AsyncMock(return_value=fake_response)
+        request_cm.__aexit__ = AsyncMock(return_value=False)
+
+        session = MagicMock()
+        session.closed = False
+        session.request = MagicMock(return_value=request_cm)
+        client._session = session
+
+        response = await client._make_request('GET', 'v1/account/none/none', use_cache=False)
+
+        assert response.status_code == 404
+        assert not response.success
+        # exactly one attempt - no retries with backoff
+        assert session.request.call_count == 1

--- a/tests/unit/test_rank_features.py
+++ b/tests/unit/test_rank_features.py
@@ -70,8 +70,8 @@ async def test_get_mmr_parses_response():
     assert result['elo'] == 1845
     assert result['peak'] == 'Diamond 2'
     assert result['emoji'] == '💎'
-    # base_url must be restored after the v2 swap
-    assert client.base_url == "https://api.henrikdev.xyz/valorant/v1"
+    # versioned endpoints share one immutable base URL
+    assert client.base_url == "https://api.henrikdev.xyz/valorant"
 
 
 @pytest.mark.asyncio
@@ -86,8 +86,8 @@ async def test_get_mmr_returns_none_on_exception():
     client = ValorantClient()
     client.get = AsyncMock(side_effect=Exception("boom"))
     assert await client.get_mmr('user', 'tag') is None
-    # base_url still restored even when the call blows up
-    assert client.base_url == "https://api.henrikdev.xyz/valorant/v1"
+    # base URL is never mutated, even when the call blows up
+    assert client.base_url == "https://api.henrikdev.xyz/valorant"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_rank_features.py
+++ b/tests/unit/test_rank_features.py
@@ -1,6 +1,7 @@
 """Tests for rank/RR integration, head-to-head comparison, and session recap."""
 
 import pytest
+from datetime import datetime, timezone
 from unittest.mock import MagicMock, AsyncMock, patch
 import discord
 
@@ -278,7 +279,13 @@ async def test_session_recap_with_games(discord_member_factory):
                 2: [{'username': 'Bob', 'tag': 'NA1', 'puuid': 'pb'}]}
     fake_client.get_all_linked_accounts.side_effect = lambda uid: accounts.get(uid, [])
     fake_client.get_linked_account.side_effect = lambda uid: accounts.get(uid, [None])[0]
-    fake_client.get_match_history = AsyncMock(return_value=[match])
+    fake_client.get_recent_competitive_updates = AsyncMock(return_value=[
+        {'match_id': 'm1',
+         'started_at': datetime(2024, 1, 1, 0, 30, tzinfo=timezone.utc),
+         'rr_change': 20}
+    ])
+    fake_client.get_match_details = AsyncMock(return_value=match)
+    fake_client.record_match_stats_for_players = MagicMock(return_value=2)
     fake_client.get_mmr = AsyncMock(return_value=None)
 
     session = _make_session('2024-01-01T00:00:00+00:00', '2024-01-01T02:00:00+00:00', 120)
@@ -309,7 +316,8 @@ async def test_session_recap_no_games(discord_member_factory):
     fake_client = MagicMock()
     fake_client.get_all_linked_accounts.return_value = []
     fake_client.get_linked_account.return_value = None
-    fake_client.get_match_history = AsyncMock(return_value=[])
+    fake_client.get_recent_competitive_updates = AsyncMock(return_value=[])
+    fake_client.get_match_details = AsyncMock(return_value=None)
     fake_client.get_mmr = AsyncMock(return_value=None)
 
     session = _make_session('2024-01-01T00:00:00+00:00', '2024-01-01T00:45:00+00:00', 45)
@@ -329,18 +337,16 @@ async def test_session_recap_excludes_out_of_window_matches(discord_member_facto
     m1.bot = False
     guild = MagicMock(spec=discord.Guild)
 
-    # Match started long before the session window
-    old_match = {
-        'metadata': {'matchid': 'old', 'game_start': '2023-12-01T00:00:00Z'},
-        'teams': {'red': {'has_won': True}, 'blue': {'has_won': False}},
-        'players': {'all_players': [
-            {'puuid': 'pa', 'team': 'Red', 'stats': {'kills': 25, 'deaths': 10, 'assists': 5}},
-        ]},
-    }
+    # Match played long before the session window
     fake_client = MagicMock()
     fake_client.get_all_linked_accounts.return_value = [{'username': 'Alice', 'tag': 'NA1', 'puuid': 'pa'}]
     fake_client.get_linked_account.return_value = {'username': 'Alice', 'tag': 'NA1', 'puuid': 'pa'}
-    fake_client.get_match_history = AsyncMock(return_value=[old_match])
+    fake_client.get_recent_competitive_updates = AsyncMock(return_value=[
+        {'match_id': 'old',
+         'started_at': datetime(2023, 12, 1, 0, 0, tzinfo=timezone.utc),
+         'rr_change': 20}
+    ])
+    fake_client.get_match_details = AsyncMock()
     fake_client.get_mmr = AsyncMock(return_value=None)
 
     session = _make_session('2024-01-01T00:00:00+00:00', '2024-01-01T02:00:00+00:00', 120)
@@ -349,3 +355,5 @@ async def test_session_recap_excludes_out_of_window_matches(discord_member_facto
         embed = await tracker.build_session_recap(guild, [m1], session)
 
     assert any('No tracked games' in f.name for f in embed.fields)
+    # Out-of-window matches must not trigger a (heavy) details fetch
+    fake_client.get_match_details.assert_not_called()

--- a/tests/unit/test_valorant_client.py
+++ b/tests/unit/test_valorant_client.py
@@ -19,7 +19,7 @@ class TestValorantClientInit:
         """Test client initialization with API key"""
         client = ValorantClient()
         
-        assert client.base_url == "https://api.henrikdev.xyz/valorant/v1"
+        assert client.base_url == "https://api.henrikdev.xyz/valorant"
         assert client.api_key == 'test_api_key'
         # Authorization header is now handled by BaseAPIClient
         auth_headers = client._get_auth_headers()
@@ -30,7 +30,7 @@ class TestValorantClientInit:
         """Test client initialization without API key"""
         client = ValorantClient()
         
-        assert client.base_url == "https://api.henrikdev.xyz/valorant/v1"
+        assert client.base_url == "https://api.henrikdev.xyz/valorant"
         assert client.api_key == ''
         # No authorization headers when no API key
         auth_headers = client._get_auth_headers()
@@ -105,7 +105,7 @@ class TestAccountAPI:
         result = await client.get_account_info("TestPlayer", "NA1")
         
         # Verify the call
-        mock_get.assert_called_once_with('account/TestPlayer/NA1', cache_ttl=300)
+        mock_get.assert_called_once_with('v1/account/TestPlayer/NA1', cache_ttl=300)
         
         # Verify the result
         assert result is not None
@@ -129,7 +129,7 @@ class TestAccountAPI:
         result = await client.get_account_info("NonExistent", "USER")
 
         assert result is None
-        mock_get.assert_called_once_with('account/NonExistent/USER', cache_ttl=300)
+        mock_get.assert_called_once_with('v1/account/NonExistent/USER', cache_ttl=300)
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("status_code,expected_none", [
@@ -148,7 +148,7 @@ class TestAccountAPI:
 
             result = await client.get_account_info("User", "TAG")
 
-            mock_get.assert_called_once_with('account/User/TAG', cache_ttl=300)
+            mock_get.assert_called_once_with('v1/account/User/TAG', cache_ttl=300)
 
             if expected_none:
                 assert result is None
@@ -219,8 +219,9 @@ class TestMatchHistoryAPI:
 
             result = await client.get_match_history("User", "TAG")
 
+            # PUUID is known, so the by-puuid matchlist endpoint is used
             mock_get.assert_called_once_with(
-                'matches/na/User/TAG',
+                'v3/by-puuid/matches/na/abc',
                 params={'size': 5},
                 cache_ttl=180
             )

--- a/valorant_client.py
+++ b/valorant_client.py
@@ -144,8 +144,7 @@ class ValorantClient(BaseAPIClient):
             response = await self.get(f'v1/account/{username}/{tag}', cache_ttl=300)
             
             if response.success:
-                # Henrik API wraps data in 'data' field
-                account_data = response.data['data'] if 'data' in response.data else response.data
+                account_data = self._unwrap(response)
                 
                 # Store the account data permanently
                 database_manager.store_account(account_data, username=username, tag=tag)
@@ -402,7 +401,8 @@ class ValorantClient(BaseAPIClient):
             return None
 
     async def get_recent_competitive_updates(self, username: str, tag: str,
-                                             puuid: str = None) -> Optional[List[Dict[str, Any]]]:
+                                             puuid: str = None,
+                                             force_refresh: bool = False) -> Optional[List[Dict[str, Any]]]:
         """Get the player's recent competitive updates (lightweight, live data).
 
         Uses the v1 mmr-history endpoint: a small payload listing recent
@@ -421,7 +421,7 @@ class ValorantClient(BaseAPIClient):
             else:
                 endpoint = f'v1/mmr-history/{self.region}/{username}/{tag}'
 
-            response = await self.get(endpoint, cache_ttl=60)
+            response = await self.get(endpoint, use_cache=not force_refresh, cache_ttl=60)
             if not response.success:
                 logging.debug(f"mmr-history fetch failed for {username}#{tag}: {response.status_code}")
                 return None
@@ -659,8 +659,10 @@ class ValorantClient(BaseAPIClient):
 
         rounds_data = match.get('rounds', [])
         if not rounds_data:
-            # No round data available - fall back to estimates
-            self._estimate_round_stats(player_data, row, len(rounds_data), bool(row.get('won')))
+            # No round data available - fall back to estimates over the
+            # match's reported round count
+            self._estimate_round_stats(player_data, row, row.get('rounds_played', 0) or 0,
+                                       bool(row.get('won')))
             return
 
         player_team = (players.get(player_puuid, {}).get('team') or '').lower()
@@ -1150,6 +1152,7 @@ class ValorantClient(BaseAPIClient):
             if ordered_ids:
                 known = database_manager.get_player_match_stats_for_ids(puuid, ordered_ids)
                 missing = [mid for mid in ordered_ids if mid not in known]
+                new_rows = []  # (puuid, match_id, row) persisted in one batch
 
                 # Fill from permanently stored match data (no API cost)
                 still_missing = []
@@ -1157,7 +1160,7 @@ class ValorantClient(BaseAPIClient):
                     stored = database_manager.get_stored_match(mid)
                     row = self.build_match_stats_row(stored, puuid) if stored else None
                     if row:
-                        database_manager.store_player_match_stats(puuid, mid, row)
+                        new_rows.append((puuid, mid, row))
                         known[mid] = row
                     else:
                         still_missing.append(mid)
@@ -1176,7 +1179,7 @@ class ValorantClient(BaseAPIClient):
                         if mid in still_missing:
                             row = self.build_match_stats_row(match, puuid)
                             if row:
-                                database_manager.store_player_match_stats(puuid, mid, row)
+                                new_rows.append((puuid, mid, row))
                                 known[mid] = row
                     still_missing = [mid for mid in still_missing if mid not in known]
 
@@ -1185,8 +1188,10 @@ class ValorantClient(BaseAPIClient):
                     match = await self.get_match_details(mid)
                     row = self.build_match_stats_row(match, puuid) if match else None
                     if row:
-                        database_manager.store_player_match_stats(puuid, mid, row)
+                        new_rows.append((puuid, mid, row))
                         known[mid] = row
+
+                database_manager.store_player_match_stats_bulk(new_rows)
 
                 rows = [known[mid] for mid in ordered_ids if mid in known]
                 if mode_norm:
@@ -1202,21 +1207,27 @@ class ValorantClient(BaseAPIClient):
             if matches is None:
                 return None
 
-            # Persist what we fetched so future calls are incremental
+            # Compute rows once: persist them for future incremental calls and
+            # aggregate the same rows for the response
+            rows = []
+            new_rows = []
             for match in matches:
-                mid = self._match_id_of(match)
-                if not mid or not match.get('is_available', True):
+                if not match.get('is_available', True):
                     continue
-                database_manager.store_match(mid, match)
-                if mode_norm and mode_norm == 'competitive' and not self._is_competitive_match(match):
+                mid = self._match_id_of(match)
+                if mid:
+                    database_manager.store_match(mid, match)
+                if mode_norm == 'competitive' and not self._is_competitive_match(match):
                     continue
                 row = self.build_match_stats_row(match, puuid)
-                if row:
-                    database_manager.store_player_match_stats(puuid, mid, row)
+                if not row:
+                    continue
+                rows.append(row)
+                if mid:
+                    new_rows.append((puuid, mid, row))
+            database_manager.store_player_match_stats_bulk(new_rows)
 
-            return self.calculate_player_stats(
-                matches, puuid, competitive_only=(mode_norm == 'competitive')
-            )
+            return self.aggregate_match_rows(rows)
         except Exception as e:
             log_error(f"getting player stats for {username}#{tag}", e)
             return None
@@ -1263,15 +1274,15 @@ class ValorantClient(BaseAPIClient):
         if not match_id:
             return 0
 
-        count = 0
+        entries = []
         for puuid in {p for p in puuids if p}:
             try:
                 row = self.build_match_stats_row(match_data, puuid)
-                if row and database_manager.store_player_match_stats(puuid, match_id, row):
-                    count += 1
+                if row:
+                    entries.append((puuid, match_id, row))
             except Exception as e:
                 log_error(f"recording match stats for {puuid} in {match_id}", e)
-        return count
+        return database_manager.store_player_match_stats_bulk(entries)
 
     def _calculate_streaks(self, stats: Dict[str, Any]):
         """Calculate win/loss streaks from recent matches"""

--- a/valorant_client.py
+++ b/valorant_client.py
@@ -1,9 +1,10 @@
 import logging
+from collections import defaultdict
 from typing import Optional, Dict, Any, List
 import discord
 from data_manager import data_manager
-from config import HENRIK_API_KEY
-from utils import log_error
+from config import HENRIK_API_KEY, VALORANT_REGION, HENRIK_REQUESTS_PER_MINUTE
+from utils import log_error, parse_henrik_timestamp
 from api_clients import BaseAPIClient, RateLimitInfo, APIResponse
 from database import database_manager
 
@@ -63,29 +64,46 @@ def get_player_rank(player_data: Dict[str, Any]) -> Optional[str]:
 
 
 class ValorantClient(BaseAPIClient):
-    """Client for interacting with Henrik's Valorant API"""
-    
+    """Client for interacting with Henrik's Valorant API.
+
+    Endpoint paths carry an explicit version prefix (v1/v2/v3) against a single
+    base URL, so concurrent requests to different API versions are safe — the
+    base URL is never mutated. Wherever a PUUID is known, the by-puuid endpoint
+    variants are used: they skip Henrik's internal Riot-ID resolution and keep
+    working when players rename.
+    """
+
+    # v3 matchlist endpoints return full match details and cap size at 10
+    MATCH_LIST_MAX_SIZE = 10
+    # Bound how many single-match detail fetches one stats call may trigger
+    MAX_DETAIL_FETCHES = 10
+    # If at least this many matches are missing, bulk-fetch via the matchlist
+    # endpoint (1 request for up to 10 matches) instead of per-match requests
+    BULK_FETCH_THRESHOLD = 3
+
     def __init__(self):
-        # Henrik API rate limits: 100 requests per 2 minutes for free tier
-        # Advanced tier has higher limits
+        # Henrik API rate limits per key tier: Basic = 30 req/min, Advanced = 90
+        # (configure HENRIK_REQUESTS_PER_MINUTE to match your key)
         rate_limit = RateLimitInfo(
-            requests_per_second=1.0,
-            requests_per_minute=50 if HENRIK_API_KEY else 30,
-            requests_per_hour=1500 if HENRIK_API_KEY else 600,
+            requests_per_second=2.0,
+            requests_per_minute=HENRIK_REQUESTS_PER_MINUTE,
+            requests_per_hour=HENRIK_REQUESTS_PER_MINUTE * 60,
             burst_limit=5
         )
-        
+
         super().__init__(
-            base_url="https://api.henrikdev.xyz/valorant/v1",
+            base_url="https://api.henrikdev.xyz/valorant",
             api_key=HENRIK_API_KEY,
             rate_limit=rate_limit,
             timeout=30
         )
-        
+
+        self.region = VALORANT_REGION
+
         if HENRIK_API_KEY:
-            logging.info("Using Henrik API with Advanced key")
+            logging.info(f"Using Henrik API with key ({HENRIK_REQUESTS_PER_MINUTE} req/min, region {self.region})")
         else:
-            logging.info("Using Henrik API Basic tier (no key)")
+            logging.info("Using Henrik API without key - most endpoints now require one")
     
     @property
     def headers(self) -> Dict[str, str]:
@@ -101,17 +119,18 @@ class ValorantClient(BaseAPIClient):
     async def health_check(self) -> bool:
         """Check if the Henrik API is healthy."""
         try:
-            # Use a simple endpoint to check API health
-            response = await self.get('status', use_cache=False, cache_ttl=0)
-            return response.success
+            response = await self.get(f'v1/status/{self.region}', use_cache=False, cache_ttl=0)
+            if response.success:
+                return True
         except Exception:
-            # If no status endpoint, try a basic query
-            try:
-                response = await self.get('account/test/0000', use_cache=False, cache_ttl=0)
-                # Even 404 means API is responding
-                return response.status_code in [200, 404]
-            except Exception:
-                return False
+            pass
+        # If the status endpoint is unavailable, try a basic query
+        try:
+            response = await self.get('v1/account/test/0000', use_cache=False, cache_ttl=0)
+            # Even 404 means API is responding
+            return response.status_code in [200, 404]
+        except Exception:
+            return False
     
     async def get_account_info(self, username: str, tag: str) -> Optional[Dict[str, Any]]:
         """Get account information by username and tag"""
@@ -122,7 +141,7 @@ class ValorantClient(BaseAPIClient):
                 logging.debug(f"Using stored account info for {username}#{tag}")
                 return stored_account
             
-            response = await self.get(f'account/{username}/{tag}', cache_ttl=300)
+            response = await self.get(f'v1/account/{username}/{tag}', cache_ttl=300)
             
             if response.success:
                 # Henrik API wraps data in 'data' field
@@ -244,13 +263,33 @@ class ValorantClient(BaseAPIClient):
         
         return playing_members
     
+    @staticmethod
+    def _unwrap(response: APIResponse) -> Any:
+        """Henrik API wraps payloads in a 'data' field."""
+        if isinstance(response.data, dict) and 'data' in response.data:
+            return response.data['data']
+        return response.data
+
+    @staticmethod
+    def _usable_puuid(puuid: Optional[str]) -> Optional[str]:
+        """Return the puuid unless it's a placeholder from /shootymanuallink."""
+        if puuid and not str(puuid).startswith('manual_'):
+            return puuid
+        return None
+
     async def get_match_history(self, username: str, tag: str, size: int = 5, mode: str = None, force_refresh: bool = False) -> Optional[List[Dict[str, Any]]]:
-        """Get match history for a player
-        
+        """Get full match details for a player's recent matches (heavy call).
+
+        This hits the v3 matchlist endpoint which returns *complete* match
+        objects (all players, all rounds, all kill events) fetched live from
+        Riot — payloads are large. Prefer get_player_stats() for stats and
+        get_stored_matches_light() / get_recent_competitive_updates() for
+        polling; use this only when full match details are actually needed.
+
         Args:
             username: Valorant username
             tag: Valorant tag
-            size: Number of matches to fetch (default 5)
+            size: Number of matches to fetch (API max is 10)
             mode: Game mode filter (competitive, unrated, replication, etc.)
         """
         try:
@@ -258,59 +297,185 @@ class ValorantClient(BaseAPIClient):
             account_info = await self.get_account_info(username, tag)
             if not account_info:
                 return None
-            
+
             puuid = account_info.get('puuid')
             if not puuid:
                 return None
-            
+
+            size = min(size, self.MATCH_LIST_MAX_SIZE)
+
             # Check database storage first (unless forcing refresh)
             if not force_refresh:
-                # Use shorter cache time for manual checks to get fresher data
-                max_age = 2 if force_refresh else 10  # 2 minutes for fresh, 10 for normal
-                stored_data = database_manager.get_stored_player_stats(puuid, mode, size, max_age_minutes=max_age)
+                stored_data = database_manager.get_stored_player_stats(puuid, mode, size, max_age_minutes=10)
                 if stored_data:
                     stats_data, match_history_data = stored_data
                     logging.debug(f"Using stored match history for {username}#{tag}")
                     return match_history_data
-            
-            # Match history uses v3 API with different base URL
-            # Temporarily change the base URL for this request
-            original_base_url = self.base_url
-            self.base_url = "https://api.henrikdev.xyz/valorant/v3"
-            
-            try:
-                params = {'size': size}
-                if mode:
-                    params['filter'] = mode
-                    
-                response = await self.get(
-                    f'matches/na/{username}/{tag}',
-                    params=params,
-                    cache_ttl=180  # Cache for 3 minutes
-                )
-                
-                if response.success:
-                    # Henrik API wraps data in 'data' field
-                    match_history = response.data['data'] if 'data' in response.data else response.data
-                    
-                    # Calculate stats and store both together
-                    stats = self.calculate_player_stats(match_history, puuid, competitive_only=(mode == 'competitive'))
-                    database_manager.store_player_stats(puuid, mode, size, stats, match_history)
-                    
-                    return match_history
-                else:
-                    log_error("fetching match history", Exception(f"Status {response.status_code}"))
-                    return None
-            finally:
-                # Restore original base URL
-                self.base_url = original_base_url
-                
+
+            params = {'size': size}
+            if mode:
+                # Henrik has accepted both names across versions; send both
+                params['filter'] = mode
+                params['mode'] = mode
+
+            usable_puuid = self._usable_puuid(puuid)
+            if usable_puuid:
+                endpoint = f'v3/by-puuid/matches/{self.region}/{usable_puuid}'
+            else:
+                endpoint = f'v3/matches/{self.region}/{username}/{tag}'
+
+            response = await self.get(endpoint, params=params, cache_ttl=180)
+
+            if response.success:
+                match_history = self._unwrap(response)
+
+                # Calculate stats and store both together
+                stats = self.calculate_player_stats(match_history, puuid, competitive_only=(mode == 'competitive'))
+                database_manager.store_player_stats(puuid, mode, size, stats, match_history)
+
+                return match_history
+            else:
+                log_error("fetching match history", Exception(f"Status {response.status_code}"))
+                return None
+
         except Exception as e:
             log_error("fetching match history", e)
             return None
 
-    async def get_mmr(self, username: str, tag: str, region: str = 'na',
-                      force_refresh: bool = False) -> Optional[Dict[str, Any]]:
+    async def get_stored_matches_light(self, username: str, tag: str, puuid: str = None,
+                                       size: int = 20, mode: str = None,
+                                       force_refresh: bool = False) -> Optional[List[Dict[str, Any]]]:
+        """Get a lightweight match list from Henrik's stored-matches endpoint.
+
+        Served from Henrik's database (no live Riot fetch): each entry has only
+        match metadata, the requested player's own scoreboard line, and team
+        scores — a tiny payload compared to full match details, and cheaper
+        against the API quota. No round/kill-event data.
+
+        Returns a normalized list (most recent first)::
+
+            [{'match_id', 'started_at' (ISO str or None), 'map', 'mode',
+              'stats' (player's own line), 'teams'}, ...]
+        """
+        try:
+            usable_puuid = self._usable_puuid(puuid)
+            if usable_puuid:
+                endpoint = f'v1/by-puuid/stored-matches/{self.region}/{usable_puuid}'
+            else:
+                endpoint = f'v1/stored-matches/{self.region}/{username}/{tag}'
+
+            params = {'size': size}
+            if mode:
+                params['mode'] = mode
+
+            response = await self.get(
+                endpoint, params=params,
+                use_cache=not force_refresh,
+                cache_ttl=60
+            )
+            if not response.success:
+                logging.debug(f"stored-matches fetch failed for {username}#{tag}: {response.status_code}")
+                return None
+
+            entries = self._unwrap(response) or []
+            normalized = []
+            for entry in entries:
+                meta = entry.get('meta', {}) or {}
+                match_id = meta.get('id')
+                if not match_id:
+                    continue
+                started = parse_henrik_timestamp(meta.get('started_at'))
+                map_info = meta.get('map') or {}
+                normalized.append({
+                    'match_id': match_id,
+                    'started_at': started.isoformat() if started else None,
+                    'map': map_info.get('name') if isinstance(map_info, dict) else map_info,
+                    'mode': (meta.get('mode') or '').lower() or None,
+                    'stats': entry.get('stats', {}),
+                    'teams': entry.get('teams', {}),
+                })
+
+            normalized.sort(key=lambda m: m['started_at'] or '', reverse=True)
+            return normalized
+        except Exception as e:
+            log_error(f"fetching stored matches for {username}#{tag}", e)
+            return None
+
+    async def get_recent_competitive_updates(self, username: str, tag: str,
+                                             puuid: str = None) -> Optional[List[Dict[str, Any]]]:
+        """Get the player's recent competitive updates (lightweight, live data).
+
+        Uses the v1 mmr-history endpoint: a small payload listing recent
+        competitive matches with match ids, timestamps and RR changes. This is
+        the cheap way to detect "did this player finish a new comp match?" —
+        the old approach pulled the full match details every poll.
+
+        Returns a normalized list (most recent first)::
+
+            [{'match_id', 'started_at' (datetime or None), 'rr_change'}, ...]
+        """
+        try:
+            usable_puuid = self._usable_puuid(puuid)
+            if usable_puuid:
+                endpoint = f'v1/by-puuid/mmr-history/{self.region}/{usable_puuid}'
+            else:
+                endpoint = f'v1/mmr-history/{self.region}/{username}/{tag}'
+
+            response = await self.get(endpoint, cache_ttl=60)
+            if not response.success:
+                logging.debug(f"mmr-history fetch failed for {username}#{tag}: {response.status_code}")
+                return None
+
+            entries = self._unwrap(response) or []
+            normalized = []
+            for entry in entries:
+                match_id = entry.get('match_id')
+                if not match_id:
+                    continue
+                started = None
+                if entry.get('date_raw'):
+                    started = parse_henrik_timestamp(entry.get('date_raw'))
+                if started is None:
+                    started = parse_henrik_timestamp(entry.get('date'))
+                normalized.append({
+                    'match_id': match_id,
+                    'started_at': started,
+                    'rr_change': entry.get('mmr_change_to_last_game'),
+                })
+            return normalized
+        except Exception as e:
+            log_error(f"fetching competitive updates for {username}#{tag}", e)
+            return None
+
+    async def get_match_details(self, match_id: str) -> Optional[Dict[str, Any]]:
+        """Get full details for a single match, permanently cached in SQLite.
+
+        Completed matches are immutable, so once stored they are never fetched
+        again. Skips the in-memory response cache — payloads are large and the
+        database is the cache.
+        """
+        if not match_id:
+            return None
+        try:
+            stored = database_manager.get_stored_match(match_id)
+            if stored:
+                return stored
+
+            response = await self.get(f'v2/match/{match_id}', use_cache=False)
+            if not response.success:
+                logging.warning(f"Match details fetch failed for {match_id}: {response.status_code}")
+                return None
+
+            match_data = self._unwrap(response)
+            if match_data:
+                database_manager.store_match(match_id, match_data)
+            return match_data
+        except Exception as e:
+            log_error(f"fetching match details for {match_id}", e)
+            return None
+
+    async def get_mmr(self, username: str, tag: str, region: str = None,
+                      force_refresh: bool = False, puuid: str = None) -> Optional[Dict[str, Any]]:
         """Fetch a player's current rank / RR info from Henrik's MMR endpoint.
 
         Returns a normalized dict::
@@ -329,62 +494,393 @@ class ValorantClient(BaseAPIClient):
         gracefully.
         """
         try:
-            # MMR lives on the v2 API; swap the base URL like get_match_history.
-            original_base_url = self.base_url
-            self.base_url = "https://api.henrikdev.xyz/valorant/v2"
-            try:
-                response = await self.get(
-                    f'mmr/{region}/{username}/{tag}',
-                    use_cache=not force_refresh,
-                    cache_ttl=120  # Cache rank for 2 minutes
-                )
+            region = region or self.region
+            usable_puuid = self._usable_puuid(puuid)
+            if usable_puuid:
+                endpoint = f'v2/by-puuid/mmr/{region}/{usable_puuid}'
+            else:
+                endpoint = f'v2/mmr/{region}/{username}/{tag}'
 
-                if not response.success:
-                    logging.warning(f"MMR fetch failed for {username}#{tag}: {response.status_code}")
-                    return None
+            response = await self.get(
+                endpoint,
+                use_cache=not force_refresh,
+                cache_ttl=120  # Cache rank for 2 minutes
+            )
 
-                data = response.data['data'] if 'data' in response.data else response.data
-                if not data:
-                    return None
+            if not response.success:
+                logging.warning(f"MMR fetch failed for {username}#{tag}: {response.status_code}")
+                return None
 
-                current = data.get('current_data', {}) or {}
-                highest = data.get('highest_rank', {}) or {}
+            data = self._unwrap(response)
+            if not data:
+                return None
 
-                patched = current.get('currenttierpatched') or tier_name(current.get('currenttier'))
-                return {
-                    'tier': patched,
-                    'rr': current.get('ranking_in_tier'),
-                    'rr_change': current.get('mmr_change_to_last_game'),
-                    'elo': current.get('elo'),
-                    'peak': highest.get('patched_tier'),
-                    'emoji': rank_emoji(patched),
-                }
-            finally:
-                self.base_url = original_base_url
+            current = data.get('current_data', {}) or {}
+            highest = data.get('highest_rank', {}) or {}
+
+            patched = current.get('currenttierpatched') or tier_name(current.get('currenttier'))
+            return {
+                'tier': patched,
+                'rr': current.get('ranking_in_tier'),
+                'rr_change': current.get('mmr_change_to_last_game'),
+                'elo': current.get('elo'),
+                'peak': highest.get('patched_tier'),
+                'emoji': rank_emoji(patched),
+            }
 
         except Exception as e:
             log_error(f"fetching MMR for {username}#{tag}", e)
             return None
 
+    # ------------------------------------------------------------------
+    # Stats pipeline
+    #
+    # Architecture: completed matches are immutable, so each (player, match)
+    # stat line is computed exactly once (build_match_stats_row), persisted to
+    # the queryable player_match_stats table, and aggregate stats are built by
+    # folding rows together (aggregate_match_rows). New statlines can be added
+    # by extending the row dict / 'extra' JSON column without re-fetching
+    # anything from the API.
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _is_competitive_match(match: Dict[str, Any]) -> bool:
+        """Check whether a match was played in the competitive queue."""
+        metadata = match.get('metadata', {})
+        fields = [
+            (metadata.get('mode') or '').lower(),
+            (metadata.get('mode_id') or '').lower(),
+            (metadata.get('queue') or '').lower(),
+        ]
+        return any('competitive' in field for field in fields)
+
+    @staticmethod
+    def _match_id_of(match: Dict[str, Any]) -> Optional[str]:
+        """Extract the match id from a full match object."""
+        metadata = match.get('metadata', {})
+        return metadata.get('matchid') or metadata.get('match_id')
+
     def calculate_player_stats(self, matches: List[Dict[str, Any]], player_puuid: str, competitive_only: bool = True) -> Dict[str, Any]:
-        """Calculate comprehensive player statistics from match history using tournament-grade accuracy
-        
+        """Calculate comprehensive player statistics from full match objects.
+
+        Pure computation (no API or database access): builds one stat row per
+        match and aggregates them. Prefer get_player_stats() in command code —
+        it reuses previously computed rows from the database.
+
         Args:
-            matches: List of match data from API
+            matches: List of full match data from the API
             player_puuid: Player's PUUID to find in matches
             competitive_only: If True, only calculate stats from competitive matches
         """
         if not matches:
             return {}
-        
-        # Check storage first for this exact calculation
-        mode = 'competitive' if competitive_only else 'all'
-        stored_data = database_manager.get_stored_player_stats(player_puuid, mode, len(matches))
-        if stored_data:
-            stats_data, _ = stored_data
-            logging.debug(f"Using stored player stats for PUUID {player_puuid}")
-            return stats_data
-        
+
+        rows = []
+        for match in matches:
+            if not match.get('is_available', True):
+                continue
+            if competitive_only and not self._is_competitive_match(match):
+                continue
+            row = self.build_match_stats_row(match, player_puuid)
+            if row:
+                rows.append(row)
+
+        return self.aggregate_match_rows(rows)
+
+    def build_match_stats_row(self, match: Dict[str, Any], player_puuid: str) -> Optional[Dict[str, Any]]:
+        """Compute one player's full stat line for a single match.
+
+        Returns a flat dict matching the player_match_stats table columns, or
+        None when the player isn't in the match. Uses the tournament-grade
+        round analysis (KAST/FK/FD/MK verified against tracker.gg) when round
+        data is present, falling back to estimates otherwise.
+        """
+        all_players = match.get('players', {}).get('all_players', [])
+        player_data = next((p for p in all_players if p.get('puuid') == player_puuid), None)
+        if not player_data:
+            return None
+
+        metadata = match.get('metadata', {})
+        pstats = player_data.get('stats', {})
+        teams = match.get('teams', {})
+        team_key = (player_data.get('team') or 'Red').lower()
+        won = teams[team_key].get('has_won', False) if team_key in teams else None
+        started = parse_henrik_timestamp(metadata.get('game_start'))
+
+        row = {
+            'mode': (metadata.get('mode_id') or metadata.get('mode') or metadata.get('queue') or '').lower() or None,
+            'map': metadata.get('map', 'Unknown'),
+            'agent': player_data.get('character', 'Unknown'),
+            'started_at': started.isoformat() if started else None,
+            'won': None if won is None else (1 if won else 0),
+            'rounds_played': metadata.get('rounds_played', 0),
+            'kills': pstats.get('kills', 0),
+            'deaths': pstats.get('deaths', 0),
+            'assists': pstats.get('assists', 0),
+            'headshots': pstats.get('headshots', 0),
+            'bodyshots': pstats.get('bodyshots', 0),
+            'legshots': pstats.get('legshots', 0),
+            'score': pstats.get('score', 0),
+            'damage_made': player_data.get('damage_made', 0),
+            'damage_received': player_data.get('damage_received', 0),
+            'kast_rounds': 0,
+            'first_bloods': 0,
+            'first_deaths': 0,
+            'multikills_2k': 0,
+            'multikills_3k': 0,
+            'multikills_4k': 0,
+            'multikills_5k': 0,
+            'rounds_survived': 0,
+            'pistol_rounds_won': 0,
+            'pistol_rounds_played': 0,
+            'eco_rounds_won': 0,
+            'eco_rounds_played': 0,
+            'shots_hit': 0,
+            'shots_fired': 0,
+            'clutches_attempted': {},
+            'clutches_won': {},
+            'weapon_kills': {},
+        }
+
+        self._compute_round_stats(match, player_data, player_puuid, row)
+        self._collect_weapon_kills(match, player_puuid, row)
+        return row
+
+    def _compute_round_stats(self, match: Dict[str, Any], player_data: Dict[str, Any],
+                             player_puuid: str, row: Dict[str, Any]) -> None:
+        """Round-by-round analysis for one match: KAST, FK/FD, multikills,
+        survival and pistol/eco rounds.
+
+        This is the proven algorithm that matches tracker.gg with 100% accuracy
+        for KAST, FK, FD and MK (validated by unit tests against real data).
+        """
+        all_players = match.get('players', {}).get('all_players', [])
+        players = {p['puuid']: p for p in all_players if p.get('puuid')}
+
+        rounds_data = match.get('rounds', [])
+        if not rounds_data:
+            # No round data available - fall back to estimates
+            self._estimate_round_stats(player_data, row, len(rounds_data), bool(row.get('won')))
+            return
+
+        player_team = (players.get(player_puuid, {}).get('team') or '').lower()
+
+        for round_num, round_data in enumerate(rounds_data):
+            round_events = round_data.get('player_stats', [])
+
+            # Track kills/deaths/assists in this round for each player
+            round_kills = defaultdict(int)
+            round_assists = defaultdict(int)
+            round_deaths = defaultdict(int)
+            round_survivors = set(players)
+
+            # Get kills from player_stats and deaths from events
+            for player_round in round_events:
+                puuid = player_round.get('player_puuid')
+                if puuid in players:
+                    round_kills[puuid] = player_round.get('kills', 0)
+
+            # Collect all kill events and determine deaths/assists
+            all_kill_events = []
+            for player_round in round_events:
+                puuid = player_round.get('player_puuid')
+                for kill_event in player_round.get('kill_events', []):
+                    all_kill_events.append({
+                        'killer_puuid': puuid,
+                        'victim_puuid': kill_event.get('victim_puuid'),
+                        'kill_time': kill_event.get('kill_time_in_round', 0),
+                    })
+
+                    victim_puuid = kill_event.get('victim_puuid')
+                    if victim_puuid in players:
+                        round_deaths[victim_puuid] += 1
+                        round_survivors.discard(victim_puuid)
+
+                    for assistant in kill_event.get('assistants', []):
+                        assist_puuid = assistant.get('puuid')
+                        if assist_puuid in players:
+                            round_assists[assist_puuid] += 1
+
+            # Additional assists from damage events (50+ damage to a player who died)
+            for player_round in round_events:
+                puuid = player_round.get('player_puuid')
+                if puuid in players and round_assists[puuid] == 0:
+                    for damage_event in player_round.get('damage_events', []):
+                        receiver_puuid = damage_event.get('receiver_puuid')
+                        damage = damage_event.get('damage', 0)
+                        if (receiver_puuid in round_deaths and
+                                round_deaths[receiver_puuid] > 0 and
+                                damage >= 50):
+                            round_assists[puuid] += 1
+                            break
+
+            # Multi-kills - exact kill counts from round data
+            kills_in_round = round_kills[player_puuid]
+            if kills_in_round >= 5:
+                row['multikills_5k'] += 1
+            elif kills_in_round == 4:
+                row['multikills_4k'] += 1
+            elif kills_in_round == 3:
+                row['multikills_3k'] += 1
+            elif kills_in_round == 2:
+                row['multikills_2k'] += 1
+
+            # First kill and first death (chronological)
+            if all_kill_events:
+                all_kill_events.sort(key=lambda x: x['kill_time'])
+                first_kill_event = all_kill_events[0]
+                if first_kill_event['killer_puuid'] == player_puuid:
+                    row['first_bloods'] += 1
+                if first_kill_event['victim_puuid'] == player_puuid:
+                    row['first_deaths'] += 1
+
+            # KAST: Kill, Assist, Survived, or Traded
+            kast_qualified = False
+            if round_kills[player_puuid] > 0:
+                kast_qualified = True
+            elif round_assists[player_puuid] > 0:
+                kast_qualified = True
+            elif player_puuid in round_survivors:
+                kast_qualified = True
+                row['rounds_survived'] += 1
+            elif round_deaths[player_puuid] > 0:
+                # Conservative trade detection: a teammate killed our killer
+                # within 3 seconds of our death
+                death_times = [e['kill_time'] for e in all_kill_events
+                               if e['victim_puuid'] == player_puuid]
+                for death_time in death_times:
+                    our_killer = next(
+                        (e['killer_puuid'] for e in all_kill_events
+                         if e['victim_puuid'] == player_puuid and e['kill_time'] == death_time),
+                        None
+                    )
+                    for event in all_kill_events:
+                        killer_team = (players.get(event['killer_puuid'], {}).get('team') or '').lower()
+                        time_diff = event['kill_time'] - death_time
+                        if (killer_team == player_team and
+                                0 < time_diff <= 3000 and
+                                event['victim_puuid'] == our_killer):
+                            kast_qualified = True
+                            break
+                    if kast_qualified:
+                        break
+
+            if kast_qualified:
+                row['kast_rounds'] += 1
+
+            # Pistol / eco round tracking (queryable extras for fun statlines)
+            winning_team = (round_data.get('winning_team') or '').lower()
+            team_won_round = bool(winning_team) and winning_team == player_team
+
+            if round_num in (0, 12):
+                row['pistol_rounds_played'] += 1
+                if team_won_round:
+                    row['pistol_rounds_won'] += 1
+
+            for player_round in round_events:
+                if player_round.get('player_puuid') == player_puuid:
+                    loadout_value = (player_round.get('economy') or {}).get('loadout_value', 0)
+                    if loadout_value and loadout_value < 2000:
+                        row['eco_rounds_played'] += 1
+                        if team_won_round:
+                            row['eco_rounds_won'] += 1
+                    break
+
+    def _estimate_round_stats(self, player_data: Dict[str, Any], row: Dict[str, Any],
+                              rounds_played: int, match_won: bool) -> None:
+        """Fallback estimates when a match has no round-by-round data."""
+        player_stats = player_data.get('stats', {})
+        kills = player_stats.get('kills', 0)
+
+        if rounds_played > 0:
+            kpr = kills / rounds_played
+
+            # Basic multikill estimation
+            if kpr >= 2.5:
+                if kpr >= 4:
+                    row['multikills_5k'] += max(1, int(kills // 5))
+                elif kpr >= 3:
+                    row['multikills_4k'] += max(1, int(kills // 4))
+                else:
+                    row['multikills_3k'] += max(1, int(kills // 3))
+                row['multikills_2k'] += max(1, int(kills // 2))
+
+            # Basic first blood estimation
+            if kpr >= 1.5:
+                estimated_first_bloods = int(rounds_played * 0.15)
+            elif kpr >= 1.0:
+                estimated_first_bloods = int(rounds_played * 0.10)
+            elif kpr >= 0.7:
+                estimated_first_bloods = int(rounds_played * 0.06)
+            else:
+                estimated_first_bloods = int(rounds_played * 0.03)
+            row['first_bloods'] += max(0, estimated_first_bloods)
+
+            # Basic survival estimation
+            deaths = player_stats.get('deaths', 0)
+            death_rate = deaths / rounds_played
+            estimated_survival_rate = max(0.3, 1.0 - death_rate)
+            row['rounds_survived'] += int(rounds_played * estimated_survival_rate)
+
+        # Basic pistol round estimation
+        if rounds_played >= 2:
+            row['pistol_rounds_played'] += 2
+            if match_won:
+                row['pistol_rounds_won'] += 1
+
+        # Shot tracking (estimate shots fired from hit stats, ~70% accuracy)
+        total_shots_hit = (player_stats.get('headshots', 0) +
+                           player_stats.get('bodyshots', 0) +
+                           player_stats.get('legshots', 0))
+        row['shots_hit'] += total_shots_hit
+        if total_shots_hit > 0:
+            row['shots_fired'] += int(total_shots_hit * 1.4)
+
+    @staticmethod
+    def _extract_weapon_name(kill_event: Dict[str, Any]) -> Optional[str]:
+        """Extract a human-readable weapon name from a kill event.
+
+        Henrik API kill events expose the weapon via ``damage_weapon_name`` and/or
+        ``damage_weapon_assets.display_name``. We try the most reliable fields first
+        and fall back to the raw id so unknown weapons are still grouped consistently.
+        """
+        assets = kill_event.get("damage_weapon_assets") or {}
+        name = (
+            kill_event.get("damage_weapon_name")
+            or assets.get("display_name")
+            or kill_event.get("damage_weapon_id")
+        )
+        if not name:
+            return None
+        name = str(name).strip()
+        return name or None
+
+    def _collect_weapon_kills(self, match: Dict[str, Any], player_puuid: str, row: Dict[str, Any]) -> None:
+        """Tally the player's kills per weapon across all rounds of a match.
+
+        Note: the Henrik API only tags weapons on kill events, not on damage
+        events, so only per-weapon kill counts can be derived (not per-weapon
+        headshot/bodyshot/legshot accuracy).
+        """
+        weapon_kills = row.setdefault('weapon_kills', {})
+
+        for round_data in match.get('rounds', []):
+            for player_round in round_data.get('player_stats', []):
+                if player_round.get('player_puuid') != player_puuid:
+                    continue
+
+                for kill_event in player_round.get('kill_events', []):
+                    weapon_name = self._extract_weapon_name(kill_event)
+                    if not weapon_name:
+                        continue
+                    weapon_kills[weapon_name] = weapon_kills.get(weapon_name, 0) + 1
+
+    def aggregate_match_rows(self, rows: List[Dict[str, Any]]) -> Dict[str, Any]:
+        """Fold per-match stat rows (newest first) into the aggregate stats dict
+        consumed by the stats/leaderboard/comparison commands."""
+        if not rows:
+            return {}
+
         stats = {
             'total_matches': 0,
             'wins': 0,
@@ -399,11 +895,10 @@ class ValorantClient(BaseAPIClient):
             'total_rounds': 0,
             'total_damage_made': 0,
             'total_damage_received': 0,
-            'kast_rounds': 0,  # Rounds with Kill, Assist, Survived, or Traded
+            'kast_rounds': 0,
             'maps_played': {},
             'agents_played': {},
             'recent_matches': [],
-            # Enhanced stats using accurate calculations
             'multikills': {'2k': 0, '3k': 0, '4k': 0, '5k': 0},
             'clutches_attempted': {'1v2': 0, '1v3': 0, '1v4': 0, '1v5': 0},
             'clutches_won': {'1v2': 0, '1v3': 0, '1v4': 0, '1v5': 0},
@@ -425,103 +920,70 @@ class ValorantClient(BaseAPIClient):
             'map_performance': {},
             'total_shots_fired': 0,
             'total_shots_hit': 0,
-            'weapon_kills': {}  # weapon display name -> kill count across all matches
+            'weapon_kills': {}
         }
-        
-        for match in matches:
-            if not match.get('is_available', True):
-                continue
-            
-            # Filter by game mode if requested
-            if competitive_only:
-                metadata = match.get('metadata', {})
-                mode = metadata.get('mode', '').lower()
-                mode_id = metadata.get('mode_id', '').lower()
-                queue = metadata.get('queue', '').lower()
-                
-                # Skip non-competitive matches
-                if not any('competitive' in field for field in [mode, mode_id, queue]):
-                    continue
-                
-            # Find the player in this match
-            player_data = None
-            all_players = match.get('players', {}).get('all_players', [])
-            
-            for player in all_players:
-                if player.get('puuid') == player_puuid:
-                    player_data = player
-                    break
-            
-            if not player_data:
-                continue
-            
+
+        for row in rows:
             stats['total_matches'] += 1
-            player_stats = player_data.get('stats', {})
-            
-            # Basic stats
-            kills = player_stats.get('kills', 0)
-            deaths = player_stats.get('deaths', 0)
-            assists = player_stats.get('assists', 0)
-            headshots = player_stats.get('headshots', 0)
-            bodyshots = player_stats.get('bodyshots', 0)
-            legshots = player_stats.get('legshots', 0)
-            score = player_stats.get('score', 0)
-            
-            # Damage stats
-            damage_made = player_data.get('damage_made', 0)
-            damage_received = player_data.get('damage_received', 0)
-            
+
+            kills = row.get('kills', 0) or 0
+            deaths = row.get('deaths', 0) or 0
+            assists = row.get('assists', 0) or 0
+            score = row.get('score', 0) or 0
+            damage_made = row.get('damage_made', 0) or 0
+            damage_received = row.get('damage_received', 0) or 0
+            rounds_played = row.get('rounds_played', 0) or 0
+
             stats['total_kills'] += kills
             stats['total_deaths'] += deaths
             stats['total_assists'] += assists
-            stats['total_headshots'] += headshots
-            stats['total_bodyshots'] += bodyshots
-            stats['total_legshots'] += legshots
+            stats['total_headshots'] += row.get('headshots', 0) or 0
+            stats['total_bodyshots'] += row.get('bodyshots', 0) or 0
+            stats['total_legshots'] += row.get('legshots', 0) or 0
             stats['total_score'] += score
             stats['total_damage_made'] += damage_made
             stats['total_damage_received'] += damage_received
-            
-            # Win/Loss calculation
-            player_team = player_data.get('team', 'Red')
-            teams = match.get('teams', {})
-            
-            if player_team.lower() in teams:
-                team_data = teams[player_team.lower()]
-                if team_data.get('has_won', False):
-                    stats['wins'] += 1
-                else:
-                    stats['losses'] += 1
-            
-            # Map tracking
-            map_name = match.get('metadata', {}).get('map', 'Unknown')
-            stats['maps_played'][map_name] = stats['maps_played'].get(map_name, 0) + 1
-            
-            # Agent tracking
-            agent_name = player_data.get('character', 'Unknown')
-            stats['agents_played'][agent_name] = stats['agents_played'].get(agent_name, 0) + 1
-            
-            # Rounds for accurate KAST and advanced stats calculation
-            rounds_played = match.get('metadata', {}).get('rounds_played', 0)
             stats['total_rounds'] += rounds_played
             stats['total_rounds_played'] += rounds_played
-            
-            # Use tournament-grade accurate stats calculation
-            match_won = teams.get(player_team.lower(), {}).get('has_won', False) if player_team.lower() in teams else False
-            
-            # Calculate accurate advanced stats for this match using the well-tested algorithm
-            self._calculate_accurate_match_stats(match, player_puuid, stats, match_won)
 
-            # Track per-weapon kills from this match's round data
-            self._track_weapon_kills(match, player_puuid, stats)
-            
+            won = row.get('won')
+            match_won = won == 1
+            if won == 1:
+                stats['wins'] += 1
+            elif won == 0:
+                stats['losses'] += 1
+
+            map_name = row.get('map') or 'Unknown'
+            agent_name = row.get('agent') or 'Unknown'
+            stats['maps_played'][map_name] = stats['maps_played'].get(map_name, 0) + 1
+            stats['agents_played'][agent_name] = stats['agents_played'].get(agent_name, 0) + 1
+
+            stats['kast_rounds'] += row.get('kast_rounds', 0) or 0
+            stats['first_bloods'] += row.get('first_bloods', 0) or 0
+            stats['first_deaths'] += row.get('first_deaths', 0) or 0
+            stats['rounds_survived'] += row.get('rounds_survived', 0) or 0
+            stats['pistol_rounds_won'] += row.get('pistol_rounds_won', 0) or 0
+            stats['pistol_rounds_played'] += row.get('pistol_rounds_played', 0) or 0
+            stats['eco_rounds_won'] += row.get('eco_rounds_won', 0) or 0
+            stats['eco_rounds_played'] += row.get('eco_rounds_played', 0) or 0
+            stats['total_shots_hit'] += row.get('shots_hit', 0) or 0
+            stats['total_shots_fired'] += row.get('shots_fired', 0) or 0
+
+            for mk_key in ('2k', '3k', '4k', '5k'):
+                stats['multikills'][mk_key] += row.get(f'multikills_{mk_key}', 0) or 0
+
+            for clutch_key in ('1v2', '1v3', '1v4', '1v5'):
+                stats['clutches_attempted'][clutch_key] += (row.get('clutches_attempted') or {}).get(clutch_key, 0)
+                stats['clutches_won'][clutch_key] += (row.get('clutches_won') or {}).get(clutch_key, 0)
+
+            for weapon, count in (row.get('weapon_kills') or {}).items():
+                stats['weapon_kills'][weapon] = stats['weapon_kills'].get(weapon, 0) + count
+
             # Agent performance tracking
-            if agent_name not in stats['agent_performance']:
-                stats['agent_performance'][agent_name] = {
-                    'matches': 0, 'wins': 0, 'kills': 0, 'deaths': 0, 'assists': 0, 
-                    'damage': 0, 'score': 0
-                }
-            
-            agent_stats = stats['agent_performance'][agent_name]
+            agent_stats = stats['agent_performance'].setdefault(agent_name, {
+                'matches': 0, 'wins': 0, 'kills': 0, 'deaths': 0, 'assists': 0,
+                'damage': 0, 'score': 0
+            })
             agent_stats['matches'] += 1
             if match_won:
                 agent_stats['wins'] += 1
@@ -530,22 +992,18 @@ class ValorantClient(BaseAPIClient):
             agent_stats['assists'] += assists
             agent_stats['damage'] += damage_made
             agent_stats['score'] += score
-            
+
             # Map performance tracking
-            if map_name not in stats['map_performance']:
-                stats['map_performance'][map_name] = {
-                    'matches': 0, 'wins': 0, 'kills': 0, 'deaths': 0, 'damage': 0
-                }
-            
-            map_stats = stats['map_performance'][map_name]
+            map_stats = stats['map_performance'].setdefault(map_name, {
+                'matches': 0, 'wins': 0, 'kills': 0, 'deaths': 0, 'damage': 0
+            })
             map_stats['matches'] += 1
             if match_won:
                 map_stats['wins'] += 1
             map_stats['kills'] += kills
             map_stats['deaths'] += deaths
             map_stats['damage'] += damage_made
-            
-            # Store recent match info
+
             stats['recent_matches'].append({
                 'map': map_name,
                 'agent': agent_name,
@@ -558,636 +1016,262 @@ class ValorantClient(BaseAPIClient):
                 'rounds_played': rounds_played,
                 'won': match_won
             })
-        
+
         # Calculate win/loss streaks
         self._calculate_streaks(stats)
-        
+
         # Calculate derived stats
-        if stats['total_matches'] > 0:
-            stats['win_rate'] = (stats['wins'] / stats['total_matches']) * 100
-            stats['avg_kills'] = stats['total_kills'] / stats['total_matches']
-            stats['avg_deaths'] = stats['total_deaths'] / stats['total_matches']
-            stats['avg_assists'] = stats['total_assists'] / stats['total_matches']
-            stats['avg_score'] = stats['total_score'] / stats['total_matches']
-            stats['avg_damage_made'] = stats['total_damage_made'] / stats['total_matches']
-            stats['avg_damage_received'] = stats['total_damage_received'] / stats['total_matches']
-            
-            # Calculate enhanced derived stats
-            stats['clutch_success_rate'] = self._calculate_clutch_success_rate(stats)
-            # First blood rate: percentage of rounds where player got first blood
-            if stats['total_rounds_played'] > 0:
-                stats['first_blood_rate'] = (stats['first_bloods'] / stats['total_rounds_played']) * 100
-            else:
-                stats['first_blood_rate'] = 0
-            # Survival rate: estimate based on deaths per round across all matches
-            # Use actual match rounds for accurate calculation
-            actual_match_rounds = sum(match.get('metadata', {}).get('rounds_played', 0) for match in matches if match.get('is_available', True) and self._player_in_match(match, player_puuid))
-            if actual_match_rounds > 0:
-                # Calculate estimated survival rate based on total deaths vs total rounds
-                death_rate = stats['total_deaths'] / actual_match_rounds
-                # Survival rate = percentage of rounds where player didn't die
-                stats['survival_rate'] = max(0, (1.0 - death_rate) * 100)
-            else:
-                stats['survival_rate'] = 0
-            
-            if stats['pistol_rounds_played'] > 0:
-                stats['pistol_win_rate'] = (stats['pistol_rounds_won'] / stats['pistol_rounds_played']) * 100
-            else:
-                stats['pistol_win_rate'] = 0
-                
-            if stats['eco_rounds_played'] > 0:
-                stats['eco_win_rate'] = (stats['eco_rounds_won'] / stats['eco_rounds_played']) * 100
-            else:
-                stats['eco_win_rate'] = 0
-                
-            # Calculate accuracy (shots hit / shots fired)
-            if stats['total_shots_fired'] > 0:
-                stats['accuracy'] = (stats['total_shots_hit'] / stats['total_shots_fired']) * 100
-            else:
-                stats['accuracy'] = 0
-                
-            # Calculate performance ratings
-            stats['performance_ratings'] = self._calculate_performance_ratings(stats)
-            
-            # Calculate DD (Damage Delta) - difference per round between damage dealt and received
-            # Use only the actual match rounds, not the estimated enhanced rounds
-            actual_match_rounds = sum(match.get('metadata', {}).get('rounds_played', 0) for match in matches if match.get('is_available', True) and self._player_in_match(match, player_puuid))
-            if actual_match_rounds > 0:
-                stats['damage_delta_per_round'] = (stats['total_damage_made'] - stats['total_damage_received']) / actual_match_rounds
-            else:
-                stats['damage_delta_per_round'] = 0
-            
-            # Calculate ACS (Average Combat Score) - simplified Valorant formula
-            # ACS is roughly: (ADR + (K/D ratio * 50) + (First Kills * 5)) but we'll use a simplified version
-            # Basic formula: (Damage per round + Kill contribution + Assist contribution)
-            if actual_match_rounds > 0:
-                adr = stats['total_damage_made'] / actual_match_rounds
-                kill_contribution = (stats['total_kills'] / actual_match_rounds) * 70  # Kills are worth ~70 ACS per round
-                assist_contribution = (stats['total_assists'] / actual_match_rounds) * 25  # Assists worth ~25 ACS per round
-                stats['acs'] = adr + kill_contribution + assist_contribution
-            else:
-                stats['acs'] = 0
-            
-            if stats['total_deaths'] > 0:
-                stats['kd_ratio'] = stats['total_kills'] / stats['total_deaths']
-                stats['kda_ratio'] = (stats['total_kills'] + stats['total_assists']) / stats['total_deaths']
-            else:
-                stats['kd_ratio'] = float(stats['total_kills'])
-                stats['kda_ratio'] = float(stats['total_kills'] + stats['total_assists'])
-            
-            # Calculate Plus/Minus (+/-) - kills minus deaths
-            stats['plus_minus'] = stats['total_kills'] - stats['total_deaths']
-            
-            total_shots = stats['total_headshots'] + stats['total_bodyshots'] + stats['total_legshots']
-            if total_shots > 0:
-                stats['headshot_percentage'] = (stats['total_headshots'] / total_shots) * 100
-            else:
-                stats['headshot_percentage'] = 0
-            
-            if actual_match_rounds > 0:
-                stats['kast_percentage'] = (stats['kast_rounds'] / actual_match_rounds) * 100
-                # Calculate ADR (Average Damage per Round)
-                stats['adr'] = stats['total_damage_made'] / actual_match_rounds
-            else:
-                stats['kast_percentage'] = 0
-                stats['adr'] = 0
-        
-        # Store the calculated stats permanently
-        mode = 'competitive' if competitive_only else 'all'
-        database_manager.store_player_stats(player_puuid, mode, len(matches), stats, matches)
-        
+        self._finalize_aggregate_stats(stats)
+
         return stats
-    
-    def _player_in_match(self, match: Dict[str, Any], player_puuid: str) -> bool:
-        """Check if a player is in a specific match"""
-        all_players = match.get('players', {}).get('all_players', [])
-        return any(player.get('puuid') == player_puuid for player in all_players)
-    
-    @staticmethod
-    def _extract_weapon_name(kill_event: Dict[str, Any]) -> Optional[str]:
-        """Extract a human-readable weapon name from a kill event.
 
-        Henrik API kill events expose the weapon via ``damage_weapon_name`` and/or
-        ``damage_weapon_assets.display_name``. We try the most reliable fields first
-        and fall back to the raw id so unknown weapons are still grouped consistently.
-        """
-        assets = kill_event.get("damage_weapon_assets") or {}
-        name = (
-            kill_event.get("damage_weapon_name")
-            or assets.get("display_name")
-            or kill_event.get("damage_weapon_id")
-        )
-        if not name:
-            return None
-        name = str(name).strip()
-        return name or None
-
-    def _track_weapon_kills(self, match: Dict[str, Any], player_puuid: str, stats: Dict[str, Any]):
-        """Tally the player's kills per weapon across all rounds of a match.
-
-        Note: the Henrik API only tags weapons on kill events, not on damage
-        events, so only per-weapon kill counts can be derived (not per-weapon
-        headshot/bodyshot/legshot accuracy).
-        """
-        weapon_kills = stats.setdefault('weapon_kills', {})
-
-        for round_data in match.get('rounds', []):
-            for player_round in round_data.get('player_stats', []):
-                if player_round.get('player_puuid') != player_puuid:
-                    continue
-
-                for kill_event in player_round.get('kill_events', []):
-                    weapon_name = self._extract_weapon_name(kill_event)
-                    if not weapon_name:
-                        continue
-                    weapon_kills[weapon_name] = weapon_kills.get(weapon_name, 0) + 1
-
-    def _calculate_accurate_match_stats(self, match: Dict[str, Any], player_puuid: str, stats: Dict[str, Any], match_won: bool):
-        """Calculate tournament-grade accurate match statistics using the proven algorithm from calculate_match_stats.py
-        
-        This implementation matches tracker.gg with 100% accuracy for KAST, FK, FD, and MK.
-        Based on comprehensive unit testing and reverse engineering of Henrik API data.
-        """
-        from collections import defaultdict
-        
-        # Get player info for this match
-        all_players = match.get('players', {}).get('all_players', [])
-        players = {player["puuid"]: player for player in all_players}
-        
-        if player_puuid not in players:
+    def _finalize_aggregate_stats(self, stats: Dict[str, Any]) -> None:
+        """Compute all derived/percentage stats from accumulated totals."""
+        if stats['total_matches'] <= 0:
             return
-        
-        # Get rounds data
-        rounds_data = match.get('rounds', [])
-        if not rounds_data:
-            # Fallback to basic estimations if no round data
-            player_data = players[player_puuid]
-            self._calculate_basic_estimates(player_data, stats, len(rounds_data), match_won)
-            return
-        
-        total_rounds = len(rounds_data)
-        
-        # Track stats for this match
-        match_kast_rounds = 0
-        match_first_kills = 0
-        match_first_deaths = 0
-        match_multi_kills = 0
-        match_rounds_survived = 0
-        
-        # Process each round using the proven accurate algorithm
-        for round_num, round_data in enumerate(rounds_data):
-            round_events = round_data.get("player_stats", [])
-            
-            # Track kills/deaths/assists in this round for each player
-            round_kills = defaultdict(int)
-            round_assists = defaultdict(int) 
-            round_deaths = defaultdict(int)
-            round_survivors = set()
-            
-            # Initialize all players as survivors (will remove those who died)
-            for puuid in players:
-                round_survivors.add(puuid)
-            
-            # Get kills from player_stats and deaths from events
-            for player_round in round_events:
-                puuid = player_round["player_puuid"]
-                if puuid in players:
-                    kills = player_round.get("kills", 0)
-                    round_kills[puuid] = kills
-            
-            # Collect all kill events from player stats and determine deaths/assists
-            all_kill_events = []
-            
-            for player_round in round_events:
-                puuid = player_round["player_puuid"]
-                
-                # Get kill events for this player
-                kill_events = player_round.get("kill_events", [])
-                for kill_event in kill_events:
-                    all_kill_events.append({
-                        "killer_puuid": puuid,
-                        "victim_puuid": kill_event.get("victim_puuid"),
-                        "kill_time": kill_event.get("kill_time_in_round", 0),
-                        "assistants": kill_event.get("assistants", [])
-                    })
-                    
-                    # Count deaths for victims
-                    victim_puuid = kill_event.get("victim_puuid")
-                    if victim_puuid in players:
-                        round_deaths[victim_puuid] += 1
-                        round_survivors.discard(victim_puuid)
-                    
-                    # Count assists
-                    for assistant in kill_event.get("assistants", []):
-                        assist_puuid = assistant.get("puuid")
-                        if assist_puuid in players:
-                            round_assists[assist_puuid] += 1
-            
-            # Check for additional assists from damage events (50+ damage threshold)
-            for player_round in round_events:
-                puuid = player_round["player_puuid"]
-                if puuid in players and round_assists[puuid] == 0:  # Only if no assists yet
-                    # Check if this player damaged someone who died this round
-                    damage_events = player_round.get("damage_events", [])
-                    for damage_event in damage_events:
-                        receiver_puuid = damage_event.get("receiver_puuid")
-                        damage = damage_event.get("damage", 0)
-                        
-                        # If they damaged someone who died this round with significant damage
-                        if (receiver_puuid in round_deaths and 
-                            round_deaths[receiver_puuid] > 0 and 
-                            damage >= 50):  # 50+ damage threshold for assists
-                            round_assists[puuid] += 1
-                            break
-            
-            # Multi-kills - record exact kill counts from round data
-            kills_in_round = round_kills[player_puuid]
 
-            if kills_in_round >= 5:
-                stats['multikills']['5k'] += 1
-                match_multi_kills += 1
-            elif kills_in_round == 4:
-                stats['multikills']['4k'] += 1
-                match_multi_kills += 1
-            elif kills_in_round == 3:
-                stats['multikills']['3k'] += 1
-                match_multi_kills += 1
-            elif kills_in_round == 2:
-                stats['multikills']['2k'] += 1
-            
-            # Determine first kill and first death
-            if all_kill_events:
-                # Sort by kill time to find first kill/death
-                all_kill_events.sort(key=lambda x: x["kill_time"])
-                
-                first_kill_event = all_kill_events[0]
-                killer_puuid = first_kill_event["killer_puuid"]
-                victim_puuid = first_kill_event["victim_puuid"]
-                
-                if killer_puuid == player_puuid:
-                    match_first_kills += 1
-                if victim_puuid == player_puuid:
-                    match_first_deaths += 1
-            
-            # KAST calculation for our player in this round
-            kast_qualified = False
-            
-            # K - Kill in round
-            if round_kills[player_puuid] > 0:
-                kast_qualified = True
-            
-            # A - Assist in round  
-            elif round_assists[player_puuid] > 0:
-                kast_qualified = True
-            
-            # S - Survived the round
-            elif player_puuid in round_survivors:
-                kast_qualified = True
-                match_rounds_survived += 1
-            
-            # T - Traded (conservative trade detection)
-            elif round_deaths[player_puuid] > 0:
-                # If player died, check if they were traded within strict conditions
-                player_team = players[player_puuid]["team"]
-                
-                # Find this player's death time(s)
-                death_times = []
-                for event in all_kill_events:
-                    if event["victim_puuid"] == player_puuid:
-                        death_times.append(event["kill_time"])
-                
-                # Check if any teammate got a kill within very tight trade window
-                for death_time in death_times:
-                    for event in all_kill_events:
-                        killer_team = players.get(event["killer_puuid"], {}).get("team")
-                        time_diff = event["kill_time"] - death_time
-                        
-                        # Very strict trade window: teammate kill within 3 seconds after death
-                        if (killer_team == player_team and 
-                            0 < time_diff <= 3000):  # 3000ms = 3 seconds after death
-                            
-                            # Additional check: was the person killed the one who killed us?
-                            victim_in_trade = event["victim_puuid"]
-                            our_killer = None
-                            for death_event in all_kill_events:
-                                if (death_event["victim_puuid"] == player_puuid and 
-                                    death_event["kill_time"] == death_time):
-                                    our_killer = death_event["killer_puuid"]
-                                    break
-                            
-                            # Only count as trade if teammate killed our killer
-                            if victim_in_trade == our_killer:
-                                kast_qualified = True
-                                break
-                        
-                        if kast_qualified:
-                            break
-            
-            if kast_qualified:
-                match_kast_rounds += 1
-        
-        # Update the player's overall stats with this match's accurate calculations
-        stats['kast_rounds'] += match_kast_rounds
-        stats['first_bloods'] += match_first_kills
-        stats['first_deaths'] += match_first_deaths
-        # match_multi_kills tracks total 3+ kill rounds for reference but
-        # individual multikill counts were already recorded above
-        stats['rounds_survived'] += match_rounds_survived
-    
-    def _calculate_match_advanced_stats(self, match: Dict[str, Any], player_data: Dict[str, Any], stats: Dict[str, Any], rounds_played: int, match_won: bool):
-        """Calculate advanced stats for a single match using round-by-round data"""
-        player_puuid = player_data.get('puuid', '')
-        
-        # Get round-by-round data for accurate calculations
-        rounds_data = match.get('rounds', [])
-        
-        if rounds_data and player_puuid:
-            # Analyze each round for accurate stats
-            self._analyze_rounds_for_player(rounds_data, player_puuid, stats, match_won, match)
+        actual_match_rounds = stats['total_rounds']
+
+        stats['win_rate'] = (stats['wins'] / stats['total_matches']) * 100
+        stats['avg_kills'] = stats['total_kills'] / stats['total_matches']
+        stats['avg_deaths'] = stats['total_deaths'] / stats['total_matches']
+        stats['avg_assists'] = stats['total_assists'] / stats['total_matches']
+        stats['avg_score'] = stats['total_score'] / stats['total_matches']
+        stats['avg_damage_made'] = stats['total_damage_made'] / stats['total_matches']
+        stats['avg_damage_received'] = stats['total_damage_received'] / stats['total_matches']
+
+        stats['clutch_success_rate'] = self._calculate_clutch_success_rate(stats)
+
+        # First blood rate: percentage of rounds where player got first blood
+        if stats['total_rounds_played'] > 0:
+            stats['first_blood_rate'] = (stats['first_bloods'] / stats['total_rounds_played']) * 100
         else:
-            # Fallback to basic estimations if no round data available
-            self._calculate_basic_estimates(player_data, stats, rounds_played, match_won)
-    
-    def _analyze_rounds_for_player(self, rounds_data: List[Dict[str, Any]], player_puuid: str, stats: Dict[str, Any], match_won: bool, match_data: Dict[str, Any] = None):
-        """Analyze round-by-round data for accurate first blood, clutch, and multikill calculations"""
-        for round_num, round_data in enumerate(rounds_data):
-            # Analyze first bloods in this round
-            self._analyze_first_bloods_in_round(round_data, player_puuid, stats)
-            
-            # Analyze clutches in this round
-            self._analyze_clutches_in_round(round_data, player_puuid, stats, match_data)
-            
-            # Analyze multikills in this round
-            self._analyze_multikills_in_round(round_data, player_puuid, stats)
-            
-            # Analyze survival in this round
-            self._analyze_survival_in_round(round_data, player_puuid, stats)
-            
-            # Analyze pistol/eco rounds
-            self._analyze_economy_rounds(round_data, round_num, player_puuid, stats, match_won, match_data)
-    
-    def _analyze_first_bloods_in_round(self, round_data: Dict[str, Any], player_puuid: str, stats: Dict[str, Any]):
-        """Analyze first blood events in a round"""
-        player_stats_in_round = round_data.get('player_stats', [])
-        
-        # Find our player in this round
-        our_player_round = None
-        for ps in player_stats_in_round:
-            if ps.get('player_puuid') == player_puuid:
-                our_player_round = ps
-                break
-        
-        if not our_player_round:
-            return
-        
-        # Check kill events for first blood
-        kill_events = our_player_round.get('kill_events', [])
-        if not kill_events:
-            return
-        
-        # Find the earliest kill time in the round across all players
-        all_kill_times = []
-        for ps in player_stats_in_round:
-            for event in ps.get('kill_events', []):
-                kill_time = event.get('kill_time_in_round')
-                if kill_time is not None:
-                    all_kill_times.append(kill_time)
-        
-        if not all_kill_times:
-            return
-        
-        earliest_kill_time = min(all_kill_times)
-        
-        # Check if our player got the first blood
-        for event in kill_events:
-            kill_time = event.get('kill_time_in_round')
-            if kill_time == earliest_kill_time:
-                stats['first_bloods'] += 1
-                break
-        
-        # Check if our player died first
-        for ps in player_stats_in_round:
-            for event in ps.get('kill_events', []):
-                if (event.get('victim_puuid') == player_puuid and 
-                    event.get('kill_time_in_round') == earliest_kill_time):
-                    stats['first_deaths'] += 1
-                    break
-    
-    def _analyze_clutches_in_round(self, round_data: Dict[str, Any], player_puuid: str, stats: Dict[str, Any], match_data: Dict[str, Any] = None):
-        """Analyze clutch situations in a round"""
-        player_stats_in_round = round_data.get('player_stats', [])
-        winning_team = round_data.get('winning_team', '')
-        
-        # Find our player and their team
-        our_player_round = None
-        for ps in player_stats_in_round:
-            if ps.get('player_puuid') == player_puuid:
-                our_player_round = ps
-                break
-        
-        if not our_player_round:
-            return
-        
-        # Get all kill events in chronological order
-        all_kill_events = []
-        for ps in player_stats_in_round:
-            for event in ps.get('kill_events', []):
-                event['round_player'] = ps.get('player_puuid')
-                all_kill_events.append(event)
-        
-        # Sort by kill time
-        all_kill_events.sort(key=lambda x: x.get('kill_time_in_round', 0))
-        
-        # Track alive players by team throughout the round
-        # This is complex without initial team info, so we'll use a simplified approach
-        # Look for situations where our player got multiple kills late in the round
-        our_kills_in_round = len(our_player_round.get('kill_events', []))
-        
-        if our_kills_in_round >= 2:
-            # Simple clutch detection: if player got 2+ kills and their team won the round
-            # This is a simplified approach - real clutch detection would need full team tracking
-            
-            # Estimate clutch situation based on kill count and round outcome
-            if our_kills_in_round >= 4:
-                # Likely a 1v4 or 1v5 clutch
-                stats['clutches_attempted']['1v5'] += 1
-                if winning_team and self._player_team_won_round(player_puuid, winning_team, match_data):
-                    stats['clutches_won']['1v5'] += 1
-            elif our_kills_in_round >= 3:
-                # Likely a 1v3 clutch
-                stats['clutches_attempted']['1v3'] += 1
-                if winning_team and self._player_team_won_round(player_puuid, winning_team, match_data):
-                    stats['clutches_won']['1v3'] += 1
-            elif our_kills_in_round >= 2:
-                # Likely a 1v2 clutch
-                stats['clutches_attempted']['1v2'] += 1
-                if winning_team and self._player_team_won_round(player_puuid, winning_team, match_data):
-                    stats['clutches_won']['1v2'] += 1
-    
-    def _analyze_multikills_in_round(self, round_data: Dict[str, Any], player_puuid: str, stats: Dict[str, Any]):
-        """Analyze multikill events in a round"""
-        player_stats_in_round = round_data.get('player_stats', [])
-        
-        # Find our player in this round
-        our_player_round = None
-        for ps in player_stats_in_round:
-            if ps.get('player_puuid') == player_puuid:
-                our_player_round = ps
-                break
-        
-        if not our_player_round:
-            return
-        
-        # Count kills in this round
-        kills_in_round = len(our_player_round.get('kill_events', []))
-        
-        # Record multikills
-        if kills_in_round >= 5:
-            stats['multikills']['5k'] += 1
-        elif kills_in_round >= 4:
-            stats['multikills']['4k'] += 1
-        elif kills_in_round >= 3:
-            stats['multikills']['3k'] += 1
-        elif kills_in_round >= 2:
-            stats['multikills']['2k'] += 1
-    
-    def _analyze_survival_in_round(self, round_data: Dict[str, Any], player_puuid: str, stats: Dict[str, Any]):
-        """Analyze whether the player survived the round (didn't die)"""
-        player_stats_in_round = round_data.get('player_stats', [])
-        
-        # Check if our player died in this round by looking at all kill events
-        player_died = False
-        
-        for ps in player_stats_in_round:
-            for event in ps.get('kill_events', []):
-                if event.get('victim_puuid') == player_puuid:
-                    player_died = True
-                    break
-            if player_died:
-                break
-        
-        # If player didn't die, they survived the round
-        if not player_died:
-            stats['rounds_survived'] += 1
-    
-    def _analyze_economy_rounds(self, round_data: Dict[str, Any], round_num: int, player_puuid: str, stats: Dict[str, Any], match_won: bool, match_data: Dict[str, Any] = None):
-        """Analyze pistol and eco rounds"""
-        # Pistol rounds are rounds 0 and 12 (first round of each half)
-        if round_num == 0 or round_num == 12:
-            stats['pistol_rounds_played'] += 1
-            
-            winning_team = round_data.get('winning_team', '')
-            if self._player_team_won_round(player_puuid, winning_team, match_data):
-                stats['pistol_rounds_won'] += 1
-        
-        # Eco round detection would require economy data analysis
-        # For now, we'll use a simplified approach
-        player_stats_in_round = round_data.get('player_stats', [])
-        for ps in player_stats_in_round:
-            if ps.get('player_puuid') == player_puuid:
-                economy = ps.get('economy', {})
-                loadout_value = economy.get('loadout_value', 0)
-                
-                # Simple eco detection: low loadout value
-                if loadout_value and loadout_value < 2000:  # Less than $2000 loadout
-                    stats['eco_rounds_played'] += 1
-                    winning_team = round_data.get('winning_team', '')
-                    if self._player_team_won_round(player_puuid, winning_team, match_data):
-                        stats['eco_rounds_won'] += 1
-                break
-    
-    def _player_team_won_round(self, player_puuid: str, winning_team: str, match_data: Dict[str, Any]) -> bool:
-        """Check if the player's team won the round"""
-        if not winning_team or not match_data:
-            return False
-        
-        # Get the player's team from match-level data
-        player_team = self._get_player_team(player_puuid, match_data)
-        if not player_team:
-            return False
-        
-        # Check if the player's team matches the winning team
-        # The winning_team format might be 'Red' or 'Blue'
-        return player_team.lower() == winning_team.lower()
-    
-    def _get_player_team(self, player_puuid: str, match_data: Dict[str, Any]) -> str:
-        """Get the team (Red/Blue) that a player is on"""
-        all_players = match_data.get('players', {}).get('all_players', [])
-        
-        for player in all_players:
-            if player.get('puuid') == player_puuid:
-                return player.get('team', '')
-        
-        # Fallback: check team-specific player lists
-        players_data = match_data.get('players', {})
-        
-        # Check red team
-        red_players = players_data.get('red', [])
-        for player in red_players:
-            if player.get('puuid') == player_puuid:
-                return 'Red'
-        
-        # Check blue team  
-        blue_players = players_data.get('blue', [])
-        for player in blue_players:
-            if player.get('puuid') == player_puuid:
-                return 'Blue'
-        
-        return ''
-    
-    def _calculate_basic_estimates(self, player_data: Dict[str, Any], stats: Dict[str, Any], rounds_played: int, match_won: bool):
-        """Fallback to basic estimations if no round data available"""
-        player_stats = player_data.get('stats', {})
-        kills = player_stats.get('kills', 0)
-        
-        # Basic multikill estimation
-        if rounds_played > 0:
-            kpr = kills / rounds_played
-            if kpr >= 2.5:  # Very high KPR suggests multikills
-                if kpr >= 4:
-                    stats['multikills']['5k'] += max(1, int(kills // 5))
-                elif kpr >= 3:
-                    stats['multikills']['4k'] += max(1, int(kills // 4))
-                elif kpr >= 2.5:
-                    stats['multikills']['3k'] += max(1, int(kills // 3))
-                stats['multikills']['2k'] += max(1, int(kills // 2))
-        
-        # Basic first blood estimation
-        if rounds_played > 0:
-            kpr = kills / rounds_played
-            if kpr >= 1.5:
-                estimated_first_bloods = int(rounds_played * 0.15)
-            elif kpr >= 1.0:
-                estimated_first_bloods = int(rounds_played * 0.10)
-            elif kpr >= 0.7:
-                estimated_first_bloods = int(rounds_played * 0.06)
-            else:
-                estimated_first_bloods = int(rounds_played * 0.03)
-            stats['first_bloods'] += max(0, estimated_first_bloods)
-        
-        # Basic pistol round estimation
-        if rounds_played >= 2:
-            stats['pistol_rounds_played'] += 2
-            if match_won:
-                stats['pistol_rounds_won'] += 1
-        
-        # Basic survival estimation (estimate rounds survived based on deaths)
-        deaths = player_stats.get('deaths', 0)
-        if rounds_played > 0:
-            # Estimate survival rate: assume death rate correlates with deaths per round
-            death_rate = deaths / rounds_played
-            # Estimate rounds survived (conservative estimation)
-            estimated_survival_rate = max(0.3, 1.0 - death_rate)  # At least 30% survival
-            estimated_rounds_survived = int(rounds_played * estimated_survival_rate)
-            stats['rounds_survived'] += estimated_rounds_survived
-        
-        # Shot tracking (estimate from hit stats)
-        total_shots_hit = player_stats.get('headshots', 0) + player_stats.get('bodyshots', 0) + player_stats.get('legshots', 0)
-        stats['total_shots_hit'] += total_shots_hit
-        # Estimate shots fired (assume 60-80% accuracy for good players)
-        if total_shots_hit > 0:
-            estimated_shots_fired = int(total_shots_hit * 1.4)  # Assume ~70% accuracy
-            stats['total_shots_fired'] += estimated_shots_fired
+            stats['first_blood_rate'] = 0
+
+        # Survival rate: estimate based on deaths per round across all matches
+        if actual_match_rounds > 0:
+            death_rate = stats['total_deaths'] / actual_match_rounds
+            stats['survival_rate'] = max(0, (1.0 - death_rate) * 100)
+        else:
+            stats['survival_rate'] = 0
+
+        if stats['pistol_rounds_played'] > 0:
+            stats['pistol_win_rate'] = (stats['pistol_rounds_won'] / stats['pistol_rounds_played']) * 100
+        else:
+            stats['pistol_win_rate'] = 0
+
+        if stats['eco_rounds_played'] > 0:
+            stats['eco_win_rate'] = (stats['eco_rounds_won'] / stats['eco_rounds_played']) * 100
+        else:
+            stats['eco_win_rate'] = 0
+
+        # Accuracy (shots hit / shots fired)
+        if stats['total_shots_fired'] > 0:
+            stats['accuracy'] = (stats['total_shots_hit'] / stats['total_shots_fired']) * 100
+        else:
+            stats['accuracy'] = 0
+
+        stats['performance_ratings'] = self._calculate_performance_ratings(stats)
+
+        # DD (Damage Delta) - per-round difference between damage dealt and received
+        if actual_match_rounds > 0:
+            stats['damage_delta_per_round'] = (stats['total_damage_made'] - stats['total_damage_received']) / actual_match_rounds
+        else:
+            stats['damage_delta_per_round'] = 0
+
+        # ACS (Average Combat Score) - simplified Valorant formula
+        if actual_match_rounds > 0:
+            adr = stats['total_damage_made'] / actual_match_rounds
+            kill_contribution = (stats['total_kills'] / actual_match_rounds) * 70
+            assist_contribution = (stats['total_assists'] / actual_match_rounds) * 25
+            stats['acs'] = adr + kill_contribution + assist_contribution
+        else:
+            stats['acs'] = 0
+
+        if stats['total_deaths'] > 0:
+            stats['kd_ratio'] = stats['total_kills'] / stats['total_deaths']
+            stats['kda_ratio'] = (stats['total_kills'] + stats['total_assists']) / stats['total_deaths']
+        else:
+            stats['kd_ratio'] = float(stats['total_kills'])
+            stats['kda_ratio'] = float(stats['total_kills'] + stats['total_assists'])
+
+        # Plus/Minus (+/-) - kills minus deaths
+        stats['plus_minus'] = stats['total_kills'] - stats['total_deaths']
+
+        total_shots = stats['total_headshots'] + stats['total_bodyshots'] + stats['total_legshots']
+        if total_shots > 0:
+            stats['headshot_percentage'] = (stats['total_headshots'] / total_shots) * 100
+        else:
+            stats['headshot_percentage'] = 0
+
+        if actual_match_rounds > 0:
+            stats['kast_percentage'] = (stats['kast_rounds'] / actual_match_rounds) * 100
+            stats['adr'] = stats['total_damage_made'] / actual_match_rounds
+        else:
+            stats['kast_percentage'] = 0
+            stats['adr'] = 0
+
+    # ------------------------------------------------------------------
+    # High-level stats orchestration (incremental fetch + SQLite rows)
+    # ------------------------------------------------------------------
+
+    async def get_player_stats(self, username: str, tag: str, size: int = 20,
+                               mode: str = 'competitive',
+                               force_refresh: bool = False) -> Optional[Dict[str, Any]]:
+        """Get aggregate stats over a player's last `size` matches, cheaply.
+
+        Strategy:
+        1. Discover recent match ids via lightweight endpoints (stored-matches
+           and, for competitive, mmr-history) - tiny payloads.
+        2. Reuse per-match stat rows already in SQLite; matches are immutable
+           so rows never need recomputation.
+        3. Fetch full details only for unseen matches: one bulk matchlist call
+           when several are missing, otherwise per-match requests (bounded).
+        4. Aggregate rows into the same stats dict calculate_player_stats
+           produces.
+
+        Returns None when the account/API is unavailable; {} when no matches.
+        """
+        try:
+            account_info = await self.get_account_info(username, tag)
+            if not account_info:
+                return None
+
+            puuid = account_info.get('puuid')
+            if not puuid:
+                return None
+
+            mode_norm = mode.lower() if mode else None
+
+            ordered_ids = await self._discover_recent_match_ids(
+                username, tag, puuid, size, mode_norm, force_refresh
+            )
+
+            if ordered_ids:
+                known = database_manager.get_player_match_stats_for_ids(puuid, ordered_ids)
+                missing = [mid for mid in ordered_ids if mid not in known]
+
+                # Fill from permanently stored match data (no API cost)
+                still_missing = []
+                for mid in missing:
+                    stored = database_manager.get_stored_match(mid)
+                    row = self.build_match_stats_row(stored, puuid) if stored else None
+                    if row:
+                        database_manager.store_player_match_stats(puuid, mid, row)
+                        known[mid] = row
+                    else:
+                        still_missing.append(mid)
+
+                # Several gaps: one bulk matchlist call covers up to 10 matches
+                if len(still_missing) >= self.BULK_FETCH_THRESHOLD:
+                    matches = await self.get_match_history(
+                        username, tag, size=self.MATCH_LIST_MAX_SIZE,
+                        mode=mode_norm, force_refresh=force_refresh
+                    )
+                    for match in matches or []:
+                        mid = self._match_id_of(match)
+                        if not mid:
+                            continue
+                        database_manager.store_match(mid, match)
+                        if mid in still_missing:
+                            row = self.build_match_stats_row(match, puuid)
+                            if row:
+                                database_manager.store_player_match_stats(puuid, mid, row)
+                                known[mid] = row
+                    still_missing = [mid for mid in still_missing if mid not in known]
+
+                # Fetch the remainder individually (bounded per call)
+                for mid in still_missing[:self.MAX_DETAIL_FETCHES]:
+                    match = await self.get_match_details(mid)
+                    row = self.build_match_stats_row(match, puuid) if match else None
+                    if row:
+                        database_manager.store_player_match_stats(puuid, mid, row)
+                        known[mid] = row
+
+                rows = [known[mid] for mid in ordered_ids if mid in known]
+                if mode_norm:
+                    rows = [r for r in rows if not r.get('mode') or r.get('mode') == mode_norm]
+                if rows:
+                    return self.aggregate_match_rows(rows[:size])
+
+            # Fallback: lightweight discovery unavailable - use the matchlist
+            matches = await self.get_match_history(
+                username, tag, size=min(size, self.MATCH_LIST_MAX_SIZE),
+                mode=mode_norm, force_refresh=force_refresh
+            )
+            if matches is None:
+                return None
+
+            # Persist what we fetched so future calls are incremental
+            for match in matches:
+                mid = self._match_id_of(match)
+                if not mid or not match.get('is_available', True):
+                    continue
+                database_manager.store_match(mid, match)
+                if mode_norm and mode_norm == 'competitive' and not self._is_competitive_match(match):
+                    continue
+                row = self.build_match_stats_row(match, puuid)
+                if row:
+                    database_manager.store_player_match_stats(puuid, mid, row)
+
+            return self.calculate_player_stats(
+                matches, puuid, competitive_only=(mode_norm == 'competitive')
+            )
+        except Exception as e:
+            log_error(f"getting player stats for {username}#{tag}", e)
+            return None
+
+    async def _discover_recent_match_ids(self, username: str, tag: str, puuid: str,
+                                         size: int, mode: Optional[str],
+                                         force_refresh: bool) -> List[str]:
+        """Discover a player's recent match ids using only lightweight calls.
+
+        Combines Henrik's stored-matches (database-backed, deep history) with
+        mmr-history (live competitive updates) so brand-new competitive matches
+        are not missed. Returns ids ordered most recent first.
+        """
+        entries = []
+
+        light = await self.get_stored_matches_light(
+            username, tag, puuid=puuid, size=size, mode=mode, force_refresh=force_refresh
+        )
+        for match in light or []:
+            entries.append((match.get('started_at') or '', match['match_id']))
+
+        if mode == 'competitive':
+            updates = await self.get_recent_competitive_updates(username, tag, puuid=puuid)
+            for update in updates or []:
+                started = update.get('started_at')
+                entries.append((started.isoformat() if started else '', update['match_id']))
+
+        seen = set()
+        ordered = []
+        for _, match_id in sorted(entries, key=lambda e: e[0], reverse=True):
+            if match_id not in seen:
+                seen.add(match_id)
+                ordered.append(match_id)
+        return ordered[:size]
+
+    def record_match_stats_for_players(self, match_data: Dict[str, Any],
+                                       puuids: List[str]) -> int:
+        """Compute and persist per-match stat rows for the given players.
+
+        Used by the match tracker so one fetched match warms the stats rows of
+        every linked player who was in it. Returns the number of rows stored.
+        """
+        match_id = self._match_id_of(match_data)
+        if not match_id:
+            return 0
+
+        count = 0
+        for puuid in {p for p in puuids if p}:
+            try:
+                row = self.build_match_stats_row(match_data, puuid)
+                if row and database_manager.store_player_match_stats(puuid, match_id, row):
+                    count += 1
+            except Exception as e:
+                log_error(f"recording match stats for {puuid} in {match_id}", e)
+        return count
 
     def _calculate_streaks(self, stats: Dict[str, Any]):
         """Calculate win/loss streaks from recent matches"""


### PR DESCRIPTION
## Summary

Restructures the Valorant stats pipeline to minimize API costs and latency by adopting a tiered approach: lightweight endpoints for discovery/polling, permanent SQLite caching of immutable match details, and per-match stat rows computed once and aggregated for stats commands.

## Key Changes

**API Client Architecture**
- Removed base URL mutation pattern (v1/v2/v3 swapping); now uses versioned endpoint paths against a single immutable base URL
- Added server-reported rate limit tracking (`_server_requests_remaining`, `_server_limit_resets_at`) to honor API reset windows
- Introduced `_usable_puuid()` helper to skip placeholder PUUIDs from `/shootymanuallink` and use by-puuid endpoint variants where available

**New Lightweight Endpoints**
- `get_stored_matches_light()`: Fetches match metadata + player's own scoreline from Henrik's database (few KB vs. multi-MB full match details)
- `get_recent_competitive_updates()`: Polls v1 mmr-history for match IDs and RR changes—the cheap way to detect new matches
- `get_match_details()`: Fetches full match JSON once per match ID and permanently caches in SQLite (immutable data)

**Stats Pipeline Refactor**
- `build_match_stats_row()`: Computes one player's full stat line for a single match (tournament-grade round analysis with KAST/FK/FD/MK)
- `aggregate_match_rows()`: Folds per-match rows into aggregate stats (win rate, KDA, weapon breakdown, etc.)
- `calculate_player_stats()`: Now delegates to row building + aggregation instead of inline computation
- `get_player_stats()`: New method that reuses previously computed rows from `player_match_stats` table, fetching only unseen matches

**Database Schema**
- Added `player_match_stats` table: one row per (puuid, match_id) with all computed stat columns + JSON bags for future extensibility
- Added `henrik_matches` table: permanent cache of full match JSON (immutable, never re-fetched)

**Configuration**
- `VALORANT_REGION`: New config for default region (ap/br/eu/kr/latam/na)
- `HENRIK_REQUESTS_PER_MINUTE`: Configurable per-key tier (Basic=30, Advanced=90)
- Updated `.env.example` and `config.py` with new settings

**Match Tracking**
- `_check_recent_matches()` now uses `get_recent_competitive_updates()` (cheap poll) instead of full match history
- Full match details fetched on-demand only when a new match ID is detected

**Testing**
- Added `test_henrik_efficiency.py`: 525 lines of tests covering per-match row computation, aggregation, database round-trips, and lightweight endpoint normalization

## Implementation Details

- **Immutable match caching**: Completed matches are never re-fetched; full JSON stored in SQLite on first encounter
- **Incremental stats**: `get_player_stats()` fetches only unseen match IDs, aggregates with cached rows
- **Tournament-grade accuracy**: Round-level analysis (kill events, economy, KAST) verified against tracker.gg
- **Fallback to username/tag**: By-puuid endpoints preferred but gracefully fall back to username/tag when PUUID unavailable
- **Timestamp normalization**: New `parse_henrik_timestamp()` utility handles Henrik's varied timestamp formats
- **Rate limit awareness**: Client now respects server-reported reset windows instead of guessing locally

## Migration Notes

- Existing `get_match_history()` still works but is now documented as a "heavy call" for full match details only
- `get_player_stats()` is the new recommended method for stats commands (incremental, cached)
- Database auto-migration creates `player_match_stats` and `henrik_matches` tables on first run

https://claude.ai/code/session_01KRPM2yZiiYcmbrVu4doMTx