### PR TITLE
Remove motivational match rating footer from embed

### DIFF
--- a/match_tracker.py
+++ b/match_tracker.py
@@ -409,28 +409,6 @@ class MatchTracker:
                 value=highlights_text,
                 inline=False
             )
-            
-            # Add a motivational footer based on performance
-            total_kills = sum(dm['player_data'].get('stats', {}).get('kills', 0) for dm in discord_members)
-            if total_kills >= 50:
-                embed.add_field(
-                    name="🔥 Match Rating",
-                    value="**LEGENDARY PERFORMANCE!** 🏆 This match will be remembered!",
-                    inline=False
-                )
-            elif total_kills >= 35:
-                embed.add_field(
-                    name="⚡ Match Rating",
-                    value="**INCREDIBLE GAME!** 🎆 Outstanding teamwork!",
-                    inline=False
-                )
-
-            elif total_kills >= 25:
-                embed.add_field(
-                    name="💪 Match Rating",
-                    value="**SOLID MATCH!** 🎉 Good coordination!",
-                    inline=False
-                )
 
         # Add a post-match comment that reacts to the result, the margin, and
         # how many games deep the stack is into the session.


### PR DESCRIPTION
## Summary
Removed the motivational match rating footer section from the match embed generation in `match_tracker.py`. This section displayed performance-based messages (e.g., "LEGENDARY PERFORMANCE!", "INCREDIBLE GAME!") based on total team kills.

## Changes
- Removed the conditional logic that added a "Match Rating" field to the embed based on total kills thresholds (50+, 35+, 25+)
- Deleted three separate embed field additions with performance-based motivational messages
- Simplified the `_create_match_embed` method by removing ~22 lines of code

## Details
The removed code calculated total kills across all Discord members in the match and displayed different motivational messages based on performance tiers. This functionality has been removed, likely to streamline the embed output or shift focus to other match analysis features. The post-match comment section that follows remains intact and continues to provide contextual feedback based on match results and session depth.

https://claude.ai/code/session_01FkXMHWCzEDULqopmiz9Mkc