### PR TITLE
Extract match recap rendering into dedicated module

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -12,6 +12,7 @@ from context_manager import context_manager
 from handlers.message_formatter import DEFAULT_MSG
 from handlers.reaction_handler import add_react_options
 from match_tracker import get_match_tracker
+from match_stats_display import AdvancedStatsButton
 from utils import log_error
 from valorant_client import get_valorant_client
 
@@ -102,6 +103,9 @@ class ShootyBot(commands.Bot):
     async def setup_hook(self) -> None:
         """Called when bot is setting up."""
         await self.load_cogs()
+        # Persistent recap button: lets "📊 Advanced Stats" keep working across
+        # restarts by reloading the match from the cache via its custom id.
+        self.add_dynamic_items(AdvancedStatsButton)
 
     async def on_ready(self) -> None:
         """Called when bot is ready."""

--- a/commands/valorant_commands.py
+++ b/commands/valorant_commands.py
@@ -9,6 +9,7 @@ from valorant_client import valorant_client
 from data_manager import data_manager
 from datetime import datetime, timezone
 from match_tracker import get_match_tracker
+from match_stats_display import recap_view_from_embed
 from config import VALORANT_WEAPON_LIST
 
 
@@ -1148,7 +1149,7 @@ class ValorantCommands(BaseCommandCog):
             embed = await self.match_tracker.manual_check_recent_match(ctx.guild, member, force_fresh=fresh)
             
             if embed:
-                await ctx.send(embed=embed)
+                await ctx.send(embed=embed, view=recap_view_from_embed(embed))
             else:
                 await self.send_embed(
                     ctx,

--- a/match_stats_display.py
+++ b/match_stats_display.py
@@ -30,17 +30,35 @@ logger = logging.getLogger(__name__)
 _HALF_LENGTH = 12  # standard competitive half
 
 
+def _round_attacking_team(round_data: Dict[str, Any],
+                          puuid_team: Dict[str, str]) -> Optional[str]:
+    """The team on attack for a round, inferred from who planted the spike.
+
+    Only the attacking side can plant, so the planter's team is the attacker.
+    Returns None for rounds with no plant (e.g. a full eliminate)."""
+    planted_by = (round_data.get('plant_events') or {}).get('planted_by') or {}
+    puuid = planted_by.get('puuid')
+    if puuid and puuid in puuid_team:
+        return puuid_team[puuid]
+    return (planted_by.get('team') or '').lower() or None
+
+
 def build_round_flow(match: Dict[str, Any], team_color: str) -> str:
     """Numbered, colour-coded round-by-round strip from the squad's view.
 
     Each round shows its number, coloured green when the squad won it and red
     when they lost, rendered in a monospace ``ansi`` block so the numbers line
-    up and you can tell exactly which round was which. Rows wrap per half (and
-    again for overtime). Returns "" when round data is missing.
+    up and you can tell exactly which round was which. Each regulation half is
+    tagged ATK/DEF (inferred from who planted the spike) and rows wrap per half
+    (and again for overtime). Returns "" when round data is missing.
     """
     rounds = match.get('rounds', [])
     if not rounds or not team_color:
         return ""
+
+    all_players = match.get('players', {}).get('all_players', [])
+    puuid_team = {p.get('puuid'): (p.get('team') or '').lower()
+                  for p in all_players if p.get('puuid')}
 
     outcomes = []  # (round_number, won | None)
     for i, rd in enumerate(rounds, start=1):
@@ -48,9 +66,25 @@ def build_round_flow(match: Dict[str, Any], team_color: str) -> str:
         outcomes.append((i, (winner == team_color) if winner else None))
 
     lines = []
-    for start in range(0, len(outcomes), _HALF_LENGTH):
+    total = len(rounds)
+    for start in range(0, total, _HALF_LENGTH):
+        end = min(start + _HALF_LENGTH, total)
+
+        # Side tag. Sides hold for a regulation half but swap every round in
+        # overtime, so only the two regulation halves get an ATK/DEF label.
+        if start < 2 * _HALF_LENGTH:
+            attacker = next((t for t in (_round_attacking_team(rounds[i], puuid_team)
+                                         for i in range(start, end)) if t), None)
+            if attacker:
+                tag = (f"{_ATK}ATK{_RESET}" if attacker == team_color
+                       else f"{_DEF}DEF{_RESET}")
+            else:
+                tag = "  ?"
+        else:
+            tag = f"{_HDR} OT{_RESET}"
+
         cells = []
-        for number, won in outcomes[start:start + _HALF_LENGTH]:
+        for number, won in outcomes[start:end]:
             label = f"{number:>2}"
             if won is None:
                 cells.append(label)
@@ -58,7 +92,7 @@ def build_round_flow(match: Dict[str, Any], team_color: str) -> str:
                 cells.append(f"{_WIN}{label}{_RESET}")
             else:
                 cells.append(f"{_LOSS}{label}{_RESET}")
-        lines.append(" ".join(cells))
+        lines.append(f"{tag} │ " + " ".join(cells))
 
     return "```ansi\n" + "\n".join(lines) + "\n```"
 
@@ -119,6 +153,10 @@ _BEST_TEAM = "[0;36m"   # cyan - best on the team
 _HDR = "[1;37m"         # bold white header
 _WIN = "[0;32m"         # green team label
 _LOSS = "[0;31m"        # red team label
+
+# Round-flow side tags reuse the highlight palette: yellow attack, cyan defense.
+_ATK = _BEST_GAME
+_DEF = _BEST_TEAM
 
 _NAME_W = 14
 # (header, key, width, higher_is_better)

--- a/match_stats_display.py
+++ b/match_stats_display.py
@@ -1,0 +1,290 @@
+"""Rendering helpers for the post-match recap.
+
+Keeps the heavier presentation logic out of ``match_tracker``:
+
+* per-player display stats for the squad list (ACS / ADR),
+* the round-flow strip (emoji squares, split at half-time),
+* the advanced tracker.gg-style scoreboard rendered as a Discord ``ansi``
+  code block with the best value per column colour-highlighted, and
+* the persistent button (a ``DynamicItem`` keyed on the match id) that reveals
+  that scoreboard on demand without cluttering the recap.
+
+The button reloads the match from the permanent ``henrik_matches`` cache, so it
+keeps working across bot restarts.
+"""
+
+import logging
+import re
+from typing import Dict, List, Optional, Any
+
+import discord
+
+from valorant_client import valorant_client
+from database import database_manager
+from utils import log_error
+
+logger = logging.getLogger(__name__)
+
+# --- round flow -------------------------------------------------------------
+
+_WIN_SQUARE = "🟩"
+_LOSS_SQUARE = "🟥"
+_UNKNOWN_SQUARE = "⬜"
+_HALF_LENGTH = 12  # standard competitive half
+
+
+def build_round_flow(match: Dict[str, Any], team_color: str) -> str:
+    """A strip of 🟩/🟥 squares for the squad's win/loss each round.
+
+    Split at half-time and again for overtime (grouped in pairs) so the story
+    of the game reads left-to-right. Returns "" when round data is missing.
+    """
+    rounds = match.get('rounds', [])
+    if not rounds or not team_color:
+        return ""
+
+    squares = []
+    for rd in rounds:
+        winner = (rd.get('winning_team') or '').lower()
+        if not winner:
+            squares.append(_UNKNOWN_SQUARE)
+        elif winner == team_color:
+            squares.append(_WIN_SQUARE)
+        else:
+            squares.append(_LOSS_SQUARE)
+
+    chunks = ["".join(squares[:_HALF_LENGTH])]
+    if len(squares) > _HALF_LENGTH:
+        chunks.append("".join(squares[_HALF_LENGTH:2 * _HALF_LENGTH]))
+    if len(squares) > 2 * _HALF_LENGTH:
+        ot = squares[2 * _HALF_LENGTH:]
+        chunks.append(" ".join("".join(ot[i:i + 2]) for i in range(0, len(ot), 2)))
+
+    return "  ┃  ".join(c for c in chunks if c)
+
+
+# --- per-player display stats ----------------------------------------------
+
+def _rounds_played(match: Dict[str, Any]) -> int:
+    return (match.get('metadata', {}).get('rounds_played')
+            or len(match.get('rounds', []))
+            or 0)
+
+
+def player_display_stats(match: Dict[str, Any], player_data: Dict[str, Any],
+                         puuid: Optional[str]) -> Dict[str, Any]:
+    """Resolve the stats shown for one player in the recap.
+
+    Uses the tournament-grade row (KAST/FK/FD/MK) when the player is found in
+    the match's round data, otherwise falls back to the basic scoreboard so
+    untracked teammates and sparse test data still render.
+    """
+    rounds = _rounds_played(match) or 1
+    row = valorant_client.build_match_stats_row(match, puuid) if puuid else None
+
+    if row:
+        kills, deaths, assists = row['kills'], row['deaths'], row['assists']
+        score, damage = row['score'], row['damage_made']
+        shots = row['headshots'] + row['bodyshots'] + row['legshots']
+        hs = round(row['headshots'] / shots * 100) if shots else 0
+        kast = round(row['kast_rounds'] / rounds * 100) if rounds else 0
+        first_kills, first_deaths = row['first_bloods'], row['first_deaths']
+        multikills = row['multikills_3k'] + row['multikills_4k'] + row['multikills_5k']
+    else:
+        stats = player_data.get('stats', {})
+        kills = stats.get('kills', 0)
+        deaths = stats.get('deaths', 0)
+        assists = stats.get('assists', 0)
+        score = stats.get('score', 0)
+        damage = player_data.get('damage_made', 0)
+        shots = stats.get('headshots', 0) + stats.get('bodyshots', 0) + stats.get('legshots', 0)
+        hs = round(stats.get('headshots', 0) / shots * 100) if shots else 0
+        kast = first_kills = first_deaths = multikills = 0
+
+    return {
+        'kills': kills, 'deaths': deaths, 'assists': assists,
+        'acs': round(score / rounds) if rounds else 0,
+        'adr': round(damage / rounds) if rounds else 0,
+        'kd': kills / deaths if deaths else float(kills),
+        'hs': hs, 'kast': kast,
+        'fk': first_kills, 'fd': first_deaths, 'mk': multikills,
+    }
+
+
+# --- advanced scoreboard (ANSI) --------------------------------------------
+
+_RESET = "[0m"
+_BEST_GAME = "[1;33m"   # bold yellow - best in the whole match
+_BEST_TEAM = "[0;36m"   # cyan - best on the team
+_HDR = "[1;37m"         # bold white header
+_WIN = "[0;32m"         # green team label
+_LOSS = "[0;31m"        # red team label
+
+_NAME_W = 14
+# (header, key, width, higher_is_better)
+_COLS = [
+    ("ACS", 'acs', 4, True),
+    ("K", 'kills', 3, True),
+    ("D", 'deaths', 3, False),
+    ("A", 'assists', 3, True),
+    ("K/D", 'kd', 4, True),
+    ("ADR", 'adr', 4, True),
+    ("HS%", 'hs', 5, True),
+    ("KAST", 'kast', 5, True),
+    ("FK", 'fk', 3, True),
+    ("FD", 'fd', 3, False),
+    ("MK", 'mk', 3, True),
+]
+
+
+def _truncate(text: str, width: int) -> str:
+    return text if len(text) <= width else text[:width - 1] + "…"
+
+
+def _format_value(key: str, value: Any) -> str:
+    if key == 'kd':
+        return f"{value:.1f}"
+    if key in ('hs', 'kast'):
+        return f"{value}%"
+    return str(value)
+
+
+def _cell(key: str, value: Any, width: int, higher_is_better: bool,
+          game_best: Dict[str, Any], team_best: Dict[str, Any]) -> str:
+    """Right-justified cell, colour-wrapped if it's a leading value.
+
+    Padding happens before colour codes so column alignment is preserved (the
+    escape sequences have zero visible width).
+    """
+    text = _format_value(key, value).rjust(width)
+    if not higher_is_better or value in (0, 0.0):
+        return text
+    if value == game_best.get(key):
+        return f"{_BEST_GAME}{text}{_RESET}"
+    if value == team_best.get(key):
+        return f"{_BEST_TEAM}{text}{_RESET}"
+    return text
+
+
+def build_advanced_scoreboard(match: Dict[str, Any]) -> str:
+    """Full both-teams scoreboard as a colour-highlighted ``ansi`` code block."""
+    all_players = match.get('players', {}).get('all_players', [])
+    if not all_players:
+        return ""
+
+    teams = match.get('teams', {})
+    metadata = match.get('metadata', {})
+
+    rows = []
+    for player in all_players:
+        stats = player_display_stats(match, player, player.get('puuid'))
+        name = player.get('name', 'Unknown')
+        tag = player.get('tag', '')
+        stats['name'] = f"{name}#{tag}" if tag else name
+        rows.append((stats, (player.get('team') or '').lower()))
+
+    game_best = {key: max((r[key] for r, _ in rows), default=0)
+                 for _, key, _, hib in _COLS if hib}
+
+    header = "Player".ljust(_NAME_W) + "".join(
+        h.rjust(w + 1) for h, _, w, _ in _COLS)
+
+    lines = [f"{_HDR}{header}{_RESET}"]
+
+    def team_rounds(tcol: str) -> int:
+        return teams.get(tcol, {}).get('rounds_won', 0)
+
+    by_team: Dict[str, List[Dict[str, Any]]] = {}
+    for stats, tcol in rows:
+        by_team.setdefault(tcol, []).append(stats)
+
+    # Winner first so the scoreboard reads like the result.
+    for tcol in sorted(by_team, key=team_rounds, reverse=True):
+        members = sorted(by_team[tcol], key=lambda r: r['acs'], reverse=True)
+        team_best = {key: max((r[key] for r in members), default=0)
+                     for _, key, _, hib in _COLS if hib}
+
+        won = teams.get(tcol, {}).get('has_won', False)
+        label = f"{tcol.title() or 'Team'} — {team_rounds(tcol)}" + (" 🏆" if won else "")
+        lines.append("")
+        lines.append(f"{_WIN if won else _LOSS}{label}{_RESET}")
+
+        for r in members:
+            cells = _truncate(r['name'], _NAME_W).ljust(_NAME_W)
+            cells += "".join(
+                " " + _cell(key, r[key], w, hib, game_best, team_best)
+                for _, key, w, hib in _COLS)
+            lines.append(cells)
+
+    body = "\n".join(lines)
+    title = f"📊 **Advanced Match Stats** — {metadata.get('map', 'Unknown')}"
+    legend = "🟡 best in match · 🔵 best on team"
+    return f"{title}\n```ansi\n{body}\n```\n_{legend}_"
+
+
+# --- persistent reveal button ----------------------------------------------
+
+class AdvancedStatsButton(
+        discord.ui.DynamicItem[discord.ui.Button],
+        template=r'shooty:advstats:(?P<match_id>[\w-]+)'):
+    """Button that reveals the advanced scoreboard ephemerally.
+
+    Because it's a ``DynamicItem`` registered on the bot, it survives restarts:
+    the match id is encoded in the custom id and the match is reloaded from the
+    permanent match cache when clicked.
+    """
+
+    def __init__(self, match_id: str) -> None:
+        self.match_id = match_id
+        super().__init__(
+            discord.ui.Button(
+                label="Advanced Stats",
+                emoji="📊",
+                style=discord.ButtonStyle.secondary,
+                custom_id=f"shooty:advstats:{match_id}",
+            )
+        )
+
+    @classmethod
+    async def from_custom_id(cls, interaction: discord.Interaction,
+                             item: discord.ui.Button, match) -> "AdvancedStatsButton":
+        return cls(match["match_id"])
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        await interaction.response.defer(ephemeral=True, thinking=True)
+        match = database_manager.get_stored_match(self.match_id)
+        if not match:
+            await interaction.followup.send(
+                "Detailed stats for this match aren't cached anymore.", ephemeral=True)
+            return
+        try:
+            content = build_advanced_scoreboard(match)
+        except Exception as e:
+            log_error("building advanced scoreboard", e)
+            content = ""
+        if not content:
+            await interaction.followup.send(
+                "Couldn't build advanced stats for this match.", ephemeral=True)
+            return
+        await interaction.followup.send(content, ephemeral=True)
+
+
+def recap_view(match_id: Optional[str]) -> Optional[discord.ui.View]:
+    """A view carrying the Advanced Stats button, or None without a match id."""
+    if not match_id:
+        return None
+    view = discord.ui.View(timeout=None)
+    view.add_item(AdvancedStatsButton(match_id))
+    return view
+
+
+_MATCH_ID_RE = re.compile(r'/valorant/match/([\w-]+)')
+
+
+def recap_view_from_embed(embed: Optional[discord.Embed]) -> Optional[discord.ui.View]:
+    """Build the recap view by recovering the match id from a recap embed's
+    Tracker.gg link (used where only the embed is on hand)."""
+    if not embed or not embed.description:
+        return None
+    found = _MATCH_ID_RE.search(embed.description)
+    return recap_view(found.group(1)) if found else None

--- a/match_stats_display.py
+++ b/match_stats_display.py
@@ -27,40 +27,40 @@ logger = logging.getLogger(__name__)
 
 # --- round flow -------------------------------------------------------------
 
-_WIN_SQUARE = "🟩"
-_LOSS_SQUARE = "🟥"
-_UNKNOWN_SQUARE = "⬜"
 _HALF_LENGTH = 12  # standard competitive half
 
 
 def build_round_flow(match: Dict[str, Any], team_color: str) -> str:
-    """A strip of 🟩/🟥 squares for the squad's win/loss each round.
+    """Numbered, colour-coded round-by-round strip from the squad's view.
 
-    Split at half-time and again for overtime (grouped in pairs) so the story
-    of the game reads left-to-right. Returns "" when round data is missing.
+    Each round shows its number, coloured green when the squad won it and red
+    when they lost, rendered in a monospace ``ansi`` block so the numbers line
+    up and you can tell exactly which round was which. Rows wrap per half (and
+    again for overtime). Returns "" when round data is missing.
     """
     rounds = match.get('rounds', [])
     if not rounds or not team_color:
         return ""
 
-    squares = []
-    for rd in rounds:
+    outcomes = []  # (round_number, won | None)
+    for i, rd in enumerate(rounds, start=1):
         winner = (rd.get('winning_team') or '').lower()
-        if not winner:
-            squares.append(_UNKNOWN_SQUARE)
-        elif winner == team_color:
-            squares.append(_WIN_SQUARE)
-        else:
-            squares.append(_LOSS_SQUARE)
+        outcomes.append((i, (winner == team_color) if winner else None))
 
-    chunks = ["".join(squares[:_HALF_LENGTH])]
-    if len(squares) > _HALF_LENGTH:
-        chunks.append("".join(squares[_HALF_LENGTH:2 * _HALF_LENGTH]))
-    if len(squares) > 2 * _HALF_LENGTH:
-        ot = squares[2 * _HALF_LENGTH:]
-        chunks.append(" ".join("".join(ot[i:i + 2]) for i in range(0, len(ot), 2)))
+    lines = []
+    for start in range(0, len(outcomes), _HALF_LENGTH):
+        cells = []
+        for number, won in outcomes[start:start + _HALF_LENGTH]:
+            label = f"{number:>2}"
+            if won is None:
+                cells.append(label)
+            elif won:
+                cells.append(f"{_WIN}{label}{_RESET}")
+            else:
+                cells.append(f"{_LOSS}{label}{_RESET}")
+        lines.append(" ".join(cells))
 
-    return "  ┃  ".join(c for c in chunks if c)
+    return "```ansi\n" + "\n".join(lines) + "\n```"
 
 
 # --- per-player display stats ----------------------------------------------

--- a/match_tracker.py
+++ b/match_tracker.py
@@ -311,38 +311,72 @@ class MatchTracker:
         # Create tracker.gg link if match ID is available
         tracker_link = ""
         if match_id:
-            tracker_link = f"\n[📊 View on Tracker.gg](https://tracker.gg/valorant/match/{match_id})"
-        
-        embed = discord.Embed(
-            title="🎯 Match Results",
-            description=f"**{map_name}** • {rounds_played} rounds • {duration_str} • {time_ago_str}{tracker_link}",
-            color=0xff4655,
-            timestamp=match_timestamp
-        )
-        
+            tracker_link = f"[📊 View on Tracker.gg](https://tracker.gg/valorant/match/{match_id})"
+
         # Calculate fun stats
         fun_stats = self._calculate_fun_match_stats(match, discord_members)
-        
-        # Add team results
+
+        # Figure out which side the stack played on (all squad members are
+        # together) so the whole recap can be framed from their perspective.
+        # This drives the headline, the embed color, and the closing comment -
+        # avoiding the old layout that repeated the score and win/loss state in
+        # three different places.
         teams = match.get('teams', {})
-        if teams:
+        team_color = None
+        for dm in discord_members:
+            tc = (dm.get('player_data') or {}).get('team', '').lower()
+            if tc:
+                team_color = tc
+                break
+
+        team_won = False
+        my_rounds = 0
+        opponent_rounds = 0
+        have_result = bool(teams and team_color in teams)
+        if have_result:
+            team_won = teams[team_color].get('has_won', False)
+            my_rounds = teams[team_color].get('rounds_won', 0)
+            for color, data in teams.items():
+                if color != team_color:
+                    opponent_rounds = data.get('rounds_won', 0)
+                    break
+
+        # Single, prominent result line: outcome + scoreline shown exactly once.
+        meta_line = f"**{map_name}** • {rounds_played} rounds • {duration_str} • {time_ago_str}"
+        description_parts = []
+        if have_result:
+            outcome = "🏆 **VICTORY**" if team_won else "💀 **DEFEAT**"
+            description_parts.append(f"{outcome}　`{my_rounds} – {opponent_rounds}`")
+            embed_color = 0x3ba55d if team_won else 0xed4245
+        else:
+            embed_color = 0xff4655
+        description_parts.append(meta_line)
+        if tracker_link:
+            description_parts.append(tracker_link)
+
+        embed = discord.Embed(
+            title="🎯 Match Results",
+            description="\n".join(description_parts),
+            color=embed_color,
+            timestamp=match_timestamp
+        )
+
+        # If we couldn't tie the squad to a team, fall back to a neutral
+        # scoreboard so the result is still visible.
+        if not have_result and teams:
             team_info = []
-            for team_color, team_data in teams.items():
-                result = "🏆 **WON**" if team_data.get('has_won', False) else "❌ **LOST**"
+            for color, team_data in teams.items():
                 rounds_won = team_data.get('rounds_won', 0)
-                team_info.append(f"{team_color.title()}: {result} ({rounds_won} rounds)")
-            
+                marker = "🏆" if team_data.get('has_won', False) else "▫️"
+                team_info.append(f"{marker} {color.title()} — {rounds_won}")
             embed.add_field(
                 name="🏆 Match Result",
                 value="\n".join(team_info),
                 inline=False
             )
-        
+
         # Add Discord members who played
         member_list = []
-        stack_result = ""
-        team_color = None
-        team_won = False
         tracked_puuids = set()
 
         # Members who crossed up a full tier this game (shown inline)
@@ -352,13 +386,6 @@ class MatchTracker:
             member = dm['member']
             player_data = dm['player_data']
             stats = player_data.get('stats', {})
-
-            # Determine stack result (same for all players since they're together)
-            if not stack_result:
-                team_color = player_data.get('team', '').lower()
-                if teams and team_color in teams:
-                    team_won = teams[team_color].get('has_won', False)
-                stack_result = "🏆 WON" if team_won else "❌ LOST"
 
             puuid = dm.get('account', {}).get('puuid') or player_data.get('puuid')
             if puuid:
@@ -390,11 +417,9 @@ class MatchTracker:
                 untracked_count += 1
 
         squad_size = len(discord_members) + untracked_count
-        if not stack_result:
-            stack_result = "🏆 WON" if team_won else "❌ LOST"
 
         embed.add_field(
-            name=f"👥 Squad ({squad_size}) - {stack_result}",
+            name=f"👥 Squad ({squad_size})",
             value="\n".join(member_list) if member_list else "No squad members found",
             inline=False
         )
@@ -411,15 +436,8 @@ class MatchTracker:
             )
 
         # Add a post-match comment that reacts to the result, the margin, and
-        # how many games deep the stack is into the session.
-        my_rounds = teams.get(team_color, {}).get('rounds_won', 0) if teams else 0
-        opponent_rounds = 0
-        if teams:
-            for color, data in teams.items():
-                if color != team_color:
-                    opponent_rounds = data.get('rounds_won', 0)
-                    break
-
+        # how many games deep the stack is into the session. The scoreline is
+        # already in the headline, so the comment is pure flavor.
         if not team_won:
             name, value = self._build_loss_comment(my_rounds, opponent_rounds, game_number)
         else:
@@ -440,7 +458,7 @@ class MatchTracker:
         games that excuse runs out and we just have to keep running it back.
         """
         margin = opponent_rounds - my_rounds
-        lines = [f"Score {my_rounds}-{opponent_rounds}."]
+        lines = []
 
         if margin <= 2:
             lines.append(random.choice([
@@ -489,7 +507,7 @@ class MatchTracker:
         """Build the post-match comment shown after a win, nudging the stack to
         end on a high note once they've played a few games."""
         margin = my_rounds - opponent_rounds
-        lines = [f"Score {my_rounds}-{opponent_rounds}."]
+        lines = []
 
         if margin <= 2:
             lines.append(random.choice([

--- a/match_tracker.py
+++ b/match_tracker.py
@@ -388,7 +388,7 @@ class MatchTracker:
             flow = build_round_flow(match, team_color)
             if flow:
                 embed.add_field(
-                    name="🔄 Round Flow",
+                    name="🔄",
                     value=flow,
                     inline=False
                 )

--- a/match_tracker.py
+++ b/match_tracker.py
@@ -430,7 +430,7 @@ class MatchTracker:
             top_highlights = fun_stats['highlights'][:6]
             highlights_text = "\n".join([f"{highlight}" for highlight in top_highlights])
             embed.add_field(
-                name="🎆 Epic Match Highlights",
+                name="🎆 Match Highlights",
                 value=highlights_text,
                 inline=False
             )

--- a/match_tracker.py
+++ b/match_tracker.py
@@ -382,6 +382,17 @@ class MatchTracker:
                 inline=False
             )
 
+        # Round-by-round win/loss flow, shown right under the result so the
+        # game's story reads top-to-bottom (green = round won, red = lost).
+        if have_result:
+            flow = build_round_flow(match, team_color)
+            if flow:
+                embed.add_field(
+                    name="🔄 Round Flow  ·  🟢 won  🔴 lost",
+                    value=flow,
+                    inline=False
+                )
+
         # Add Discord members who played. Each line carries K/D/A plus the two
         # most useful per-round numbers (ACS, ADR); the top ACS in the squad
         # gets a 👑, and a one-line summary rolls the squad up.
@@ -452,12 +463,6 @@ class MatchTracker:
             value="\n".join(member_list) if member_list else "No squad members found",
             inline=False
         )
-
-        # Round-by-round win/loss flow from the squad's perspective.
-        if have_result:
-            flow = build_round_flow(match, team_color)
-            if flow:
-                embed.add_field(name="🔄 Round Flow", value=flow, inline=False)
 
         # Add enhanced fun highlights
         if fun_stats['highlights']:

--- a/match_tracker.py
+++ b/match_tracker.py
@@ -388,7 +388,7 @@ class MatchTracker:
             flow = build_round_flow(match, team_color)
             if flow:
                 embed.add_field(
-                    name="🔄 Round Flow  ·  🟢 won  🔴 lost",
+                    name="🔄 Round Flow",
                     value=flow,
                     inline=False
                 )

--- a/match_tracker.py
+++ b/match_tracker.py
@@ -8,6 +8,11 @@ import random
 from utils import log_error, format_time_ago, parse_henrik_timestamp
 from context_manager import context_manager
 from database import database_manager
+from match_stats_display import (
+    build_round_flow,
+    player_display_stats,
+    recap_view,
+)
 
 class MatchTracker:
     """Tracks Discord members' Valorant matches by polling for newly completed games in active shooty stacks"""
@@ -266,8 +271,10 @@ class MatchTracker:
 
         try:
             embed = await self._create_match_embed(match, discord_members, game_number)
+            match_id = match.get('metadata', {}).get('matchid')
             for ch in target_channels:
-                await ch.send(embed=embed)
+                # A fresh view per send avoids reusing one View across messages.
+                await ch.send(embed=embed, view=recap_view(match_id))
 
         except Exception as e:
             log_error("sending match results", e)
@@ -375,8 +382,10 @@ class MatchTracker:
                 inline=False
             )
 
-        # Add Discord members who played
-        member_list = []
+        # Add Discord members who played. Each line carries K/D/A plus the two
+        # most useful per-round numbers (ACS, ADR); the top ACS in the squad
+        # gets a 👑, and a one-line summary rolls the squad up.
+        entries = []  # (display_name, stats, rank_str, rankup_str)
         tracked_puuids = set()
 
         # Members who crossed up a full tier this game (shown inline)
@@ -385,17 +394,15 @@ class MatchTracker:
         for dm in discord_members:
             member = dm['member']
             player_data = dm['player_data']
-            stats = player_data.get('stats', {})
-
             puuid = dm.get('account', {}).get('puuid') or player_data.get('puuid')
             if puuid:
                 tracked_puuids.add(puuid)
 
-            kda = f"{stats.get('kills', 0)}/{stats.get('deaths', 0)}/{stats.get('assists', 0)}"
+            pstats = player_display_stats(match, player_data, puuid)
             rank = get_player_rank(player_data)
             rank_str = f" • {rank_emoji(rank)} {rank}" if rank else ""
             rankup_str = " ⬆️ **Rank Up!**" if member.id in ranked_up_ids else ""
-            member_list.append(f"• **{member.display_name}**: {kda}{rank_str}{rankup_str}")
+            entries.append((member.display_name, pstats, rank_str, rankup_str))
 
         # Add untracked teammates (players on the same team who aren't linked via shootylink)
         all_players = match.get('players', {}).get('all_players', [])
@@ -406,15 +413,37 @@ class MatchTracker:
                     continue
                 if player.get('puuid') in tracked_puuids:
                     continue
-                stats = player.get('stats', {})
                 name = player.get('name', 'Unknown')
                 tag = player.get('tag', '')
                 display_name = f"{name}#{tag}" if tag else name
-                kda = f"{stats.get('kills', 0)}/{stats.get('deaths', 0)}/{stats.get('assists', 0)}"
+                pstats = player_display_stats(match, player, player.get('puuid'))
                 rank = get_player_rank(player)
                 rank_str = f" • {rank_emoji(rank)} {rank}" if rank else ""
-                member_list.append(f"• **{display_name}**: {kda}{rank_str}")
+                entries.append((display_name, pstats, rank_str, ""))
                 untracked_count += 1
+
+        top_acs = max((s['acs'] for _, s, _, _ in entries), default=0)
+        member_list = []
+        for display_name, s, rank_str, rankup_str in entries:
+            crown = "👑 " if top_acs and s['acs'] == top_acs else ""
+            kda = f"{s['kills']}/{s['deaths']}/{s['assists']}"
+            extra = f" · {s['acs']} ACS · {s['adr']} ADR" if (s['acs'] or s['adr']) else ""
+            member_list.append(f"• {crown}**{display_name}**: {kda}{extra}{rank_str}{rankup_str}")
+
+        # One-line squad roll-up above the per-player lines.
+        if entries:
+            tot_k = sum(s['kills'] for _, s, _, _ in entries)
+            tot_d = sum(s['deaths'] for _, s, _, _ in entries)
+            tot_a = sum(s['assists'] for _, s, _, _ in entries)
+            avg_acs = round(sum(s['acs'] for _, s, _, _ in entries) / len(entries))
+            tot_fk = sum(s['fk'] for _, s, _, _ in entries)
+            tot_fd = sum(s['fd'] for _, s, _, _ in entries)
+            summary = f"**Squad:** {tot_k}/{tot_d}/{tot_a}"
+            if avg_acs:
+                summary += f" · {avg_acs} avg ACS"
+            if tot_fk or tot_fd:
+                summary += f" · {tot_fk} FK / {tot_fd} FD"
+            member_list.insert(0, summary)
 
         squad_size = len(discord_members) + untracked_count
 
@@ -423,6 +452,12 @@ class MatchTracker:
             value="\n".join(member_list) if member_list else "No squad members found",
             inline=False
         )
+
+        # Round-by-round win/loss flow from the squad's perspective.
+        if have_result:
+            flow = build_round_flow(match, team_color)
+            if flow:
+                embed.add_field(name="🔄 Round Flow", value=flow, inline=False)
 
         # Add enhanced fun highlights
         if fun_stats['highlights']:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-discord.py[voice]==2.3.2
+discord.py[voice]==2.7.1
 aiohttp>=3.8.0
 python-dateutil==2.8.2
 pytz==2023.3

--- a/tests/unit/test_bot.py
+++ b/tests/unit/test_bot.py
@@ -2,7 +2,7 @@
 import pytest
 import asyncio
 import os
-from unittest.mock import Mock, MagicMock, patch, AsyncMock, call
+from unittest.mock import Mock, MagicMock, patch, AsyncMock, call, PropertyMock
 import discord
 from discord.ext import commands
 
@@ -230,18 +230,19 @@ class TestCommandSync:
         guild1 = MagicMock(name="Guild1")
         guild2 = MagicMock(name="Guild2")
 
-        # Mock tree.sync
+        # Mock tree.sync (tree is a read-only property, so patch it)
         mock_synced_commands = [MagicMock(), MagicMock()]
-        bot.tree = MagicMock()
-        bot.tree.sync = AsyncMock(return_value=mock_synced_commands)
+        mock_tree = MagicMock()
+        mock_tree.sync = AsyncMock(return_value=mock_synced_commands)
 
         # Patch the guilds property
-        with patch.object(commands.Bot, 'guilds', new=[guild1, guild2]):
-            with patch('logging.info'):
-                await bot.sync_commands()
+        with patch.object(type(bot), 'tree', new_callable=PropertyMock, return_value=mock_tree):
+            with patch.object(commands.Bot, 'guilds', new=[guild1, guild2]):
+                with patch('logging.info'):
+                    await bot.sync_commands()
 
-                # Should sync to both guilds + global
-                assert bot.tree.sync.call_count == 3
+                    # Should sync to both guilds + global
+                    assert mock_tree.sync.call_count == 3
 
     @pytest.mark.asyncio
     async def test_sync_commands_handles_guild_errors(self):
@@ -257,18 +258,19 @@ class TestCommandSync:
                 raise Exception("Sync failed")
             return []
 
-        bot.tree = MagicMock()
-        bot.tree.sync = AsyncMock(side_effect=sync_with_error)
+        mock_tree = MagicMock()
+        mock_tree.sync = AsyncMock(side_effect=sync_with_error)
 
         # Patch the guilds property
-        with patch.object(commands.Bot, 'guilds', new=[guild1, guild2]):
-            with patch('logging.info'):
-                with patch('bot.log_error') as mock_error:
-                    # Should not raise exception
-                    await bot.sync_commands()
+        with patch.object(type(bot), 'tree', new_callable=PropertyMock, return_value=mock_tree):
+            with patch.object(commands.Bot, 'guilds', new=[guild1, guild2]):
+                with patch('logging.info'):
+                    with patch('bot.log_error') as mock_error:
+                        # Should not raise exception
+                        await bot.sync_commands()
 
-                    # Should log error for failed guild
-                    assert mock_error.called
+                        # Should log error for failed guild
+                        assert mock_error.called
 
 
 class TestMatchTracker:

--- a/tests/unit/test_match_stats_display.py
+++ b/tests/unit/test_match_stats_display.py
@@ -19,6 +19,10 @@ def _match():
             'Blue', 'Red', 'Blue', 'Red']            # first half (7-5)
            + ['Blue', 'Red', 'Blue', 'Red', 'Blue', 'Red'])  # 13-8 by round 18-ish
     rounds = [{'winning_team': w, 'player_stats': []} for w in seq]
+    # Spike plants reveal the attacking side: Red plants in the first half,
+    # Blue plants in the second half (so Red is ATK then DEF).
+    rounds[0]['plant_events'] = {'planted_by': {'puuid': 'Shado-id'}}
+    rounds[12]['plant_events'] = {'planted_by': {'puuid': 'Enemy1-id'}}
     return {
         'metadata': {'map': 'Ascent', 'rounds_played': len(seq), 'matchid': 'abc-123'},
         'teams': {'red': {'has_won': True, 'rounds_won': 13},
@@ -45,6 +49,24 @@ def test_round_flow_numbers_rounds_and_colours_by_outcome():
     assert f'{msd._LOSS} 3{msd._RESET}' in flow
     # Wraps to a second row after the first half (more than 12 rounds)
     assert flow.count('\n') >= 3
+
+
+def test_round_flow_labels_attack_and_defense_halves():
+    flow = msd.build_round_flow(_match(), 'red')
+    lines = [l for l in flow.splitlines() if '│' in l]
+    # Red planted first half -> ATK; Blue planted second half -> Red on DEF
+    assert 'ATK' in lines[0]
+    assert 'DEF' in lines[1]
+
+
+def test_round_flow_unknown_side_when_no_plants():
+    match = _match()
+    for rd in match['rounds']:
+        rd.pop('plant_events', None)
+    flow = msd.build_round_flow(match, 'red')
+    # No plant data -> side can't be inferred, shown as '?'
+    assert '?' in flow
+    assert 'ATK' not in flow and 'DEF' not in flow
 
 
 def test_round_flow_empty_without_rounds_or_team():

--- a/tests/unit/test_match_stats_display.py
+++ b/tests/unit/test_match_stats_display.py
@@ -35,13 +35,16 @@ def _match():
 
 # --- round flow -------------------------------------------------------------
 
-def test_round_flow_marks_wins_and_losses_from_team_perspective():
+def test_round_flow_numbers_rounds_and_colours_by_outcome():
     flow = msd.build_round_flow(_match(), 'red')
-    # First round was a Red win -> green from red's perspective
-    assert flow.startswith('🟩')
-    assert '🟥' in flow
-    # Half-time separator present (more than 12 rounds)
-    assert '┃' in flow
+    # Rendered as a monospace ansi block with round numbers
+    assert flow.startswith('```ansi')
+    assert ' 1' in flow and '13' in flow
+    # Round 1 (a Red win) is green; round 3 (a Blue win) is red, from red's view
+    assert f'{msd._WIN} 1{msd._RESET}' in flow
+    assert f'{msd._LOSS} 3{msd._RESET}' in flow
+    # Wraps to a second row after the first half (more than 12 rounds)
+    assert flow.count('\n') >= 3
 
 
 def test_round_flow_empty_without_rounds_or_team():

--- a/tests/unit/test_match_stats_display.py
+++ b/tests/unit/test_match_stats_display.py
@@ -1,0 +1,116 @@
+"""Tests for the post-match recap rendering helpers."""
+import discord
+import pytest
+
+import match_stats_display as msd
+
+
+def _player(name, tag, team, k, d, a, score, dmg, hs=30, bs=40, ls=5):
+    return {
+        'puuid': f'{name}-id', 'name': name, 'tag': tag, 'team': team,
+        'character': 'Jett', 'damage_made': dmg,
+        'stats': {'kills': k, 'deaths': d, 'assists': a, 'score': score,
+                  'headshots': hs, 'bodyshots': bs, 'legshots': ls},
+    }
+
+
+def _match():
+    seq = (['Red', 'Red', 'Blue', 'Red', 'Blue', 'Blue', 'Red', 'Red',
+            'Blue', 'Red', 'Blue', 'Red']            # first half (7-5)
+           + ['Blue', 'Red', 'Blue', 'Red', 'Blue', 'Red'])  # 13-8 by round 18-ish
+    rounds = [{'winning_team': w, 'player_stats': []} for w in seq]
+    return {
+        'metadata': {'map': 'Ascent', 'rounds_played': len(seq), 'matchid': 'abc-123'},
+        'teams': {'red': {'has_won': True, 'rounds_won': 13},
+                  'blue': {'has_won': False, 'rounds_won': 8}},
+        'rounds': rounds,
+        'players': {'all_players': [
+            _player('Shado', 'NA1', 'red', 24, 14, 7, 6200, 3900, hs=46),
+            _player('Vyn', 'NA1', 'red', 18, 16, 10, 4100, 2900),
+            _player('Enemy1', 'NA1', 'blue', 29, 14, 4, 8100, 5400, hs=10),
+            _player('Enemy2', 'NA1', 'blue', 9, 23, 3, 2700, 1800),
+        ]},
+    }
+
+
+# --- round flow -------------------------------------------------------------
+
+def test_round_flow_marks_wins_and_losses_from_team_perspective():
+    flow = msd.build_round_flow(_match(), 'red')
+    # First round was a Red win -> green from red's perspective
+    assert flow.startswith('🟩')
+    assert '🟥' in flow
+    # Half-time separator present (more than 12 rounds)
+    assert '┃' in flow
+
+
+def test_round_flow_empty_without_rounds_or_team():
+    assert msd.build_round_flow({'rounds': []}, 'red') == ""
+    assert msd.build_round_flow(_match(), '') == ""
+
+
+# --- per-player display stats ----------------------------------------------
+
+def test_player_display_stats_falls_back_to_basic_scoreboard():
+    """A player not present in the match's round data still gets ACS/ADR from
+    the basic scoreboard (KAST/FK default to 0)."""
+    match = {'metadata': {'rounds_played': 20}, 'rounds': [],
+             'players': {'all_players': []}}
+    pdata = {'stats': {'kills': 10, 'deaths': 5, 'assists': 3, 'score': 5000},
+             'damage_made': 3000}
+    s = msd.player_display_stats(match, pdata, puuid=None)
+    assert s['kills'] == 10
+    assert s['acs'] == 250   # 5000 / 20
+    assert s['adr'] == 150   # 3000 / 20
+    assert s['kast'] == 0 and s['fk'] == 0
+
+
+# --- advanced scoreboard ----------------------------------------------------
+
+def test_advanced_scoreboard_lists_all_players_in_ansi_block():
+    out = msd.build_advanced_scoreboard(_match())
+    assert '```ansi' in out
+    for name in ('Shado', 'Vyn', 'Enemy1', 'Enemy2'):
+        assert name in out
+    # Winner listed first
+    assert out.index('Red — 13') < out.index('Blue — 8')
+
+
+def test_advanced_scoreboard_highlights_match_leader():
+    out = msd.build_advanced_scoreboard(_match())
+    # Enemy1 has the top ACS (8100/18=450) so it should carry the match-best
+    # (bold yellow) ANSI code somewhere on its row.
+    enemy_line = next(l for l in out.splitlines() if l.startswith('Enemy1'))
+    assert msd._BEST_GAME in enemy_line
+
+
+def test_advanced_scoreboard_empty_without_players():
+    assert msd.build_advanced_scoreboard({'players': {'all_players': []}}) == ""
+
+
+# --- views ------------------------------------------------------------------
+
+def test_recap_view_none_without_match_id():
+    assert msd.recap_view(None) is None
+    assert msd.recap_view("") is None
+
+
+def test_recap_view_encodes_match_id_in_button():
+    view = msd.recap_view('match-xyz')
+    assert view is not None
+    button = view.children[0]
+    assert button.custom_id == 'shooty:advstats:match-xyz'
+
+
+def test_recap_view_from_embed_extracts_match_id():
+    embed = discord.Embed(
+        description="**Ascent**\n[📊 View on Tracker.gg]"
+                    "(https://tracker.gg/valorant/match/dae1b62d-c3dd-4663)")
+    view = msd.recap_view_from_embed(embed)
+    assert view is not None
+    assert view.children[0].custom_id == 'shooty:advstats:dae1b62d-c3dd-4663'
+
+
+def test_recap_view_from_embed_none_without_link():
+    embed = discord.Embed(description="**Ascent** • no link here")
+    assert msd.recap_view_from_embed(embed) is None

--- a/tests/unit/test_post_match_comments.py
+++ b/tests/unit/test_post_match_comments.py
@@ -13,7 +13,8 @@ def test_loss_comment_first_game_is_a_warmup():
     """Game 1 losses get a warm-up excuse."""
     name, value = _tracker()._build_loss_comment(my_rounds=9, opponent_rounds=13, game_number=1)
     assert name == "😅 Tough Loss"
-    assert "9-13" in value
+    # Scoreline lives in the embed headline now, not the flavor comment.
+    assert "9-13" not in value
     assert any(word in value.lower() for word in ("warm", "rust", "warming"))
 
 
@@ -28,21 +29,64 @@ def test_loss_comment_many_games_drops_warmup_and_wants_to_keep_going():
 
 def test_loss_comment_close_game_acknowledges_heartbreak():
     name, value = _tracker()._build_loss_comment(my_rounds=12, opponent_rounds=13, game_number=2)
-    assert "12-13" in value
+    assert name == "😅 Tough Loss"
+    assert value  # close-game flavor present
+    assert "12-13" not in value
 
 
 def test_win_comment_after_streak_suggests_ending_on_a_high():
     name, value = _tracker()._build_win_comment(my_rounds=13, opponent_rounds=7, game_number=3)
     assert name == "🏆 GG"
-    assert "13-7" in value
+    assert "13-7" not in value
     assert "end" in value.lower() or "high note" in value.lower() or "log off" in value.lower()
 
 
 def test_win_comment_single_game_no_end_it_nudge():
     name, value = _tracker()._build_win_comment(my_rounds=13, opponent_rounds=5, game_number=1)
     assert name == "🏆 GG"
-    # only the score line + one flavor line, no "end on that one" nudge
-    assert "13-5" in value
+    # only a single flavor line, no scoreline and no "end on that one" nudge
+    assert "13-5" not in value
+    assert "end" not in value.lower()
+
+
+@pytest.mark.asyncio
+async def test_recap_shows_result_once_in_headline(discord_member_factory):
+    """The scoreline and win/loss state appear once (in the headline), not
+    duplicated across a team-result field, the squad header, and the comment."""
+    from unittest.mock import patch, AsyncMock
+
+    tracker = _tracker()
+    match = {
+        'metadata': {'map': 'Ascent', 'rounds_played': 21, 'game_length': 1800,
+                     'game_start': '2024-01-01T00:00:00Z', 'matchid': 'abc123'},
+        'teams': {'red': {'has_won': True, 'rounds_won': 13},
+                  'blue': {'has_won': False, 'rounds_won': 8}},
+        'players': {'all_players': [
+            {'puuid': 'p1', 'name': 'Tracked', 'tag': 'NA1', 'team': 'Red',
+             'stats': {'kills': 20, 'deaths': 10, 'assists': 5}},
+        ]},
+    }
+    member = discord_member_factory(user_id=1, name='TrackedName')
+    discord_members = [{'member': member, 'account': {'puuid': 'p1'},
+                        'player_data': match['players']['all_players'][0]}]
+
+    with patch('match_tracker.format_time_ago', return_value='just now'), \
+         patch.object(tracker, '_calculate_fun_match_stats',
+                      return_value={'highlights': [], 'top_performers': {}, 'funny_stats': {}}), \
+         patch.object(tracker, '_get_ranked_up_member_ids', AsyncMock(return_value=set())):
+        embed = await tracker._create_match_embed(match, discord_members)
+
+    # Headline carries the outcome + scoreline once.
+    assert 'VICTORY' in embed.description
+    assert '13 – 8' in embed.description
+    assert embed.color.value == 0x3ba55d
+
+    # No separate per-team "Match Result" field when the squad's side is known.
+    assert not any('Match Result' in f.name for f in embed.fields)
+
+    # Squad header no longer restates WON/LOST.
+    squad_field = next(f for f in embed.fields if 'Squad' in f.name)
+    assert 'WON' not in squad_field.name and 'LOST' not in squad_field.name
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Refactors post-match recap presentation logic out of `match_tracker.py` into a new `match_stats_display.py` module. This improves code organization, testability, and enables persistent UI components (like the Advanced Stats button) that survive bot restarts.

## Key Changes

- **New `match_stats_display.py` module** with rendering helpers:
  - `build_round_flow()`: Generates colored round-by-round outcome strip with ATK/DEF labels
  - `player_display_stats()`: Computes per-player stats (ACS, ADR, KAST, FK/FD, etc.) from match data
  - `build_advanced_scoreboard()`: Creates a full both-teams ANSI-formatted scoreboard with color-highlighted best values
  - `AdvancedStatsButton`: A `DynamicItem` that persists across restarts by encoding the match ID in its custom ID
  - `recap_view()` / `recap_view_from_embed()`: Helpers to attach the Advanced Stats button to recap messages

- **Redesigned match embed layout**:
  - Single, prominent result line in headline: outcome + scoreline shown exactly once (no duplication)
  - Embed color reflects result (green for wins, red for losses)
  - Round flow strip added below result showing round-by-round progression
  - Per-player stats now include ACS/ADR alongside K/D/A, with 👑 crown for squad's top ACS
  - Squad summary line rolls up totals (K/D/A, avg ACS, FK/FD) above individual entries
  - Post-match comment no longer restates the scoreline (already in headline)

- **Updated `match_tracker.py`**:
  - Imports and uses new rendering functions from `match_stats_display`
  - Simplified `_create_match_embed()` by delegating presentation logic
  - Attaches `recap_view()` to each sent message for persistent Advanced Stats button
  - Removed redundant score/result fields that are now consolidated in the headline

- **Comprehensive test coverage**:
  - New `test_match_stats_display.py` with 11 tests covering round flow, player stats, scoreboard rendering, and button persistence
  - Updated `test_post_match_comments.py` to verify scoreline no longer appears in flavor comments
  - Updated `test_bot.py` to fix mocking of read-only `tree` property

- **Minor dependency update**: discord.py upgraded from 2.3.2 to 2.7.1 to support newer UI features

## Implementation Details

- Round flow uses ANSI color codes (green for wins, red for losses) and infers attacking side from spike plant events
- Advanced scoreboard highlights best values per column: bold yellow for match-wide best, cyan for team best
- Button custom ID format `shooty:advstats:{match_id}` allows match lookup from permanent cache on click
- Fallback to basic scoreboard stats when tournament-grade round data unavailable (untracked players, sparse test data)
- All presentation logic is pure functions (no side effects), making it easily testable and reusable

https://claude.ai/code/session_0198VepauUqxU5D6cqihUroy