### PR TITLE
Add Tracker.gg-style economy chart to post-match recap

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -13,6 +13,7 @@ from handlers.message_formatter import DEFAULT_MSG
 from handlers.reaction_handler import add_react_options
 from match_tracker import get_match_tracker
 from match_stats_display import AdvancedStatsButton
+from economy_chart import warm_up as warm_up_economy_chart
 from utils import log_error
 from valorant_client import get_valorant_client
 
@@ -106,6 +107,11 @@ class ShootyBot(commands.Bot):
         # Persistent recap button: lets "📊 Advanced Stats" keep working across
         # restarts by reloading the match from the cache via its custom id.
         self.add_dynamic_items(AdvancedStatsButton)
+        # Pre-warm the (Pi-slow) matplotlib import off the event loop so the
+        # first Advanced Stats click after a restart renders instantly instead
+        # of eating the one-time import cost. Fire-and-forget; failure is
+        # harmless (the chart just falls back to text).
+        self.loop.run_in_executor(None, warm_up_economy_chart)
 
     async def on_ready(self) -> None:
         """Called when bot is ready."""

--- a/database.py
+++ b/database.py
@@ -1060,6 +1060,27 @@ class DatabaseManager:
             finally:
                 conn.close()
 
+    def get_linked_puuids(self) -> set:
+        """All real (non-placeholder) PUUIDs linked to any Discord user.
+
+        Used to orient match visualisations from the squad's perspective.
+        ``manual_`` PUUIDs come from /shootymanuallink and aren't real Riot ids,
+        so they can't appear in match data and are excluded.
+        """
+        with self._lock:
+            conn = self._get_connection()
+            try:
+                rows = conn.execute(
+                    "SELECT DISTINCT puuid FROM valorant_accounts WHERE puuid IS NOT NULL"
+                ).fetchall()
+                return {r['puuid'] for r in rows
+                        if r['puuid'] and not str(r['puuid']).startswith('manual_')}
+            except Exception as e:
+                logging.error(f"Error getting linked puuids: {e}")
+                return set()
+            finally:
+                conn.close()
+
     def get_stored_account(self, username: str = None, tag: str = None, puuid: str = None) -> Optional[Dict[str, Any]]:
         """Get stored account data if it exists"""
         with self._lock:

--- a/economy_chart.py
+++ b/economy_chart.py
@@ -23,6 +23,28 @@ from typing import Any, Dict, List, Optional
 logger = logging.getLogger(__name__)
 
 
+def warm_up() -> bool:
+    """Eagerly import matplotlib and prime its font cache.
+
+    The first matplotlib import is slow (tens of seconds on a Pi, reading many
+    small modules off the SD card). Running this once at startup in an executor
+    moves that cost off the first user's Advanced Stats click, so every click is
+    sub-second. Blocking - run off the event loop. Returns True on success.
+    """
+    try:
+        import matplotlib
+        matplotlib.use('Agg')
+        import matplotlib.pyplot as plt
+        fig = plt.figure()          # first figure builds the font cache
+        fig.savefig(io.BytesIO(), format='png')
+        plt.close(fig)
+        logger.info("Economy chart renderer warmed up")
+        return True
+    except Exception as e:  # pragma: no cover - depends on the host env
+        logger.info("Economy chart warm-up skipped (matplotlib unavailable): %s", e)
+        return False
+
+
 def _puuid_team_map(match: Dict[str, Any]) -> Dict[str, str]:
     all_players = match.get('players', {}).get('all_players', [])
     return {p.get('puuid'): (p.get('team') or '').lower()

--- a/economy_chart.py
+++ b/economy_chart.py
@@ -1,0 +1,203 @@
+"""Tracker.gg-style per-round economy chart for the post-match recap.
+
+Renders the round-by-round *loadout-value differential* between the squad and
+the enemy: the area is green in rounds where the squad out-spent the enemy and
+red where they were out-spent, with a marker strip underneath showing who won
+each round and how (elimination / spike detonation / defuse).
+
+Everything is derived from the full match payload that the Advanced Stats
+button already reloads from the permanent ``henrik_matches`` cache, so no extra
+Henrik calls are made. ``loadout_value`` is the only economy field Henrik
+reliably populates (see ``valorant_client._compute_round_stats``), so it's what
+we chart.
+
+matplotlib is imported lazily inside :func:`render_economy_chart`; if it isn't
+installed the function returns ``None`` and callers fall back to the text-only
+scoreboard. Rendering is blocking, so callers should run it in an executor.
+"""
+
+import io
+import logging
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+
+def _puuid_team_map(match: Dict[str, Any]) -> Dict[str, str]:
+    all_players = match.get('players', {}).get('all_players', [])
+    return {p.get('puuid'): (p.get('team') or '').lower()
+            for p in all_players if p.get('puuid')}
+
+
+def pick_squad_team(match: Dict[str, Any], linked_puuids: set) -> Optional[str]:
+    """Team colour (``'red'``/``'blue'``) hosting the most linked squad members.
+
+    Falls back to the match winner so the chart still has a stable "positive"
+    reference when nobody in the match is linked. Returns ``None`` only when
+    there's no team data at all.
+    """
+    puuid_team = _puuid_team_map(match)
+    counts: Dict[str, int] = {}
+    for puuid, team in puuid_team.items():
+        if team and puuid in linked_puuids:
+            counts[team] = counts.get(team, 0) + 1
+    if counts:
+        return max(counts, key=counts.get)
+
+    teams = match.get('teams', {})
+    winner = next((c for c, d in teams.items() if d.get('has_won')), None)
+    if winner:
+        return winner.lower()
+    return next(iter(teams), None)
+
+
+def _round_condition(round_data: Dict[str, Any]) -> str:
+    """How the round ended: ``'defuse'``, ``'plant'`` (detonation) or ``'elim'``."""
+    if (round_data.get('defuse_events') or {}).get('defused_by'):
+        return 'defuse'
+    if (round_data.get('plant_events') or {}).get('planted_by'):
+        return 'plant'
+    return 'elim'
+
+
+def compute_round_economy(match: Dict[str, Any],
+                          squad_team: str) -> List[Dict[str, Any]]:
+    """Per-round economy data from the squad's perspective.
+
+    Returns one dict per round with the squad/enemy loadout totals, their
+    difference, whether the squad won the round (``None`` if unknown) and the
+    win condition. Returns ``[]`` when round data is missing.
+    """
+    rounds = match.get('rounds', [])
+    if not rounds or not squad_team:
+        return []
+    squad_team = squad_team.lower()
+    puuid_team = _puuid_team_map(match)
+
+    result: List[Dict[str, Any]] = []
+    for i, rd in enumerate(rounds, start=1):
+        squad_loadout = enemy_loadout = 0
+        for ps in rd.get('player_stats', []):
+            team = puuid_team.get(ps.get('player_puuid'), '')
+            loadout = (ps.get('economy') or {}).get('loadout_value', 0) or 0
+            if team == squad_team:
+                squad_loadout += loadout
+            elif team:
+                enemy_loadout += loadout
+
+        winner = (rd.get('winning_team') or '').lower()
+        result.append({
+            'round': i,
+            'squad_loadout': squad_loadout,
+            'enemy_loadout': enemy_loadout,
+            'diff': squad_loadout - enemy_loadout,
+            'squad_won': (winner == squad_team) if winner else None,
+            'condition': _round_condition(rd),
+        })
+    return result
+
+
+# Marker shapes mirror the round-condition icons on tracker.gg's economy tab.
+_CONDITION_MARKER = {'elim': 'x', 'plant': '^', 'defuse': 'v'}
+
+_BG = '#101820'
+_GREEN = '#3ba55d'
+_RED = '#ed4245'
+_GRID = '#2b3543'
+_TEXT = '#c8d0da'
+
+
+def render_economy_chart(match: Dict[str, Any],
+                         squad_team: Optional[str]) -> Optional[io.BytesIO]:
+    """Render the economy chart to a PNG ``BytesIO``.
+
+    Returns ``None`` (so callers fall back to text) when matplotlib is missing,
+    round data is unavailable, or rendering fails. Blocking — run in an executor.
+    """
+    if not squad_team:
+        return None
+    data = compute_round_economy(match, squad_team)
+    if not data:
+        return None
+
+    try:
+        import matplotlib
+        matplotlib.use('Agg')  # headless: no display needed on the Pi
+        import matplotlib.pyplot as plt
+        from matplotlib.ticker import FuncFormatter
+    except Exception as e:  # pragma: no cover - depends on the host env
+        logger.info("Economy chart skipped (matplotlib unavailable): %s", e)
+        return None
+
+    try:
+        rounds = [d['round'] for d in data]
+        diff_k = [d['diff'] / 1000 for d in data]
+
+        teams = match.get('teams', {})
+        squad_team = squad_team.lower()
+        enemy_team = next((c for c in teams if c.lower() != squad_team), None)
+        squad_rounds = teams.get(squad_team, {}).get('rounds_won', 0)
+        enemy_rounds = (teams.get(enemy_team, {}).get('rounds_won', 0)
+                        if enemy_team else 0)
+        map_name = match.get('metadata', {}).get('map', 'Unknown')
+
+        fig, ax = plt.subplots(figsize=(9, 3.6), dpi=110)
+        fig.patch.set_facecolor(_BG)
+        ax.set_facecolor(_BG)
+
+        ax.fill_between(rounds, diff_k, 0, where=[v >= 0 for v in diff_k],
+                        interpolate=True, color=_GREEN, alpha=0.45)
+        ax.fill_between(rounds, diff_k, 0, where=[v <= 0 for v in diff_k],
+                        interpolate=True, color=_RED, alpha=0.45)
+        ax.plot(rounds, diff_k, color=_TEXT, linewidth=1.4, zorder=3)
+        for d, y in zip(data, diff_k):
+            ax.plot(d['round'], y, marker='o', markersize=4, zorder=4,
+                    color=_GREEN if d['diff'] >= 0 else _RED)
+        ax.axhline(0, color=_TEXT, linewidth=1.0, alpha=0.8)
+
+        # Round-outcome strip beneath the plot: green = squad won, red = lost,
+        # marker shape encodes the win condition.
+        span = max((abs(v) for v in diff_k), default=1) or 1
+        strip_y = -span * 1.25
+        for d in data:
+            if d['squad_won'] is None:
+                color = _GRID
+            else:
+                color = _GREEN if d['squad_won'] else _RED
+            ax.scatter(d['round'], strip_y, s=46, zorder=5, color=color,
+                       marker=_CONDITION_MARKER.get(d['condition'], 'x'),
+                       linewidths=1.4)
+        ax.set_ylim(strip_y - span * 0.35, span * 1.2)
+
+        ax.set_xlim(0.5, len(rounds) + 0.5)
+        ax.set_xticks(rounds)
+        ax.tick_params(colors=_TEXT, labelsize=7)
+        ax.yaxis.set_major_formatter(FuncFormatter(lambda v, _: f"{v:+.0f}k"))
+        for spine in ax.spines.values():
+            spine.set_visible(False)
+        ax.grid(axis='y', color=_GRID, linewidth=0.6, alpha=0.6)
+        ax.set_axisbelow(True)
+
+        ax.set_title(
+            f"Economy — {map_name}   "
+            f"Squad {squad_rounds} : {enemy_rounds} Enemy",
+            color=_TEXT, fontsize=11, fontweight='bold', pad=10)
+        ax.set_ylabel("Loadout advantage", color=_TEXT, fontsize=8)
+        fig.text(0.5, 0.005,
+                 "▲ green = squad richer · ▼ red = enemy richer    "
+                 "strip: ✕ elim · ▲ detonation · ▼ defuse",
+                 color=_TEXT, fontsize=6.5, alpha=0.75, ha='center')
+
+        fig.tight_layout(rect=(0, 0.04, 1, 1))
+        buf = io.BytesIO()
+        fig.savefig(buf, format='png', facecolor=_BG)
+        plt.close(fig)
+        buf.seek(0)
+        return buf
+    except Exception as e:
+        logger.warning("Failed to render economy chart: %s", e)
+        try:
+            plt.close('all')
+        except Exception:
+            pass
+        return None

--- a/match_stats_display.py
+++ b/match_stats_display.py
@@ -13,6 +13,7 @@ The button reloads the match from the permanent ``henrik_matches`` cache, so it
 keeps working across bot restarts.
 """
 
+import asyncio
 import logging
 import re
 from typing import Dict, List, Optional, Any
@@ -21,6 +22,7 @@ import discord
 
 from valorant_client import valorant_client
 from database import database_manager
+from economy_chart import render_economy_chart, pick_squad_team
 from utils import log_error
 
 logger = logging.getLogger(__name__)
@@ -304,7 +306,31 @@ class AdvancedStatsButton(
             await interaction.followup.send(
                 "Couldn't build advanced stats for this match.", ephemeral=True)
             return
-        await interaction.followup.send(content, ephemeral=True)
+
+        chart_file = await self._build_economy_chart(match)
+        if chart_file is not None:
+            await interaction.followup.send(content, file=chart_file, ephemeral=True)
+        else:
+            await interaction.followup.send(content, ephemeral=True)
+
+    @staticmethod
+    async def _build_economy_chart(match) -> Optional[discord.File]:
+        """Render the round-economy chart off the event loop, or None on failure.
+
+        Rendering is CPU-bound (matplotlib), so it runs in the default executor
+        to avoid stalling the bot. Any failure degrades silently to text-only.
+        """
+        try:
+            squad_team = pick_squad_team(match, database_manager.get_linked_puuids())
+            loop = asyncio.get_running_loop()
+            buf = await loop.run_in_executor(
+                None, render_economy_chart, match, squad_team)
+            if buf is None:
+                return None
+            return discord.File(buf, filename="economy.png")
+        except Exception as e:
+            log_error("building economy chart", e)
+            return None
 
 
 def recap_view(match_id: Optional[str]) -> Optional[discord.ui.View]:

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ filelock==3.12.2
 python-dotenv==1.0.0
 requests==2.31.0
 psutil==5.9.8
+matplotlib>=3.5.0  # post-match economy chart (recap Advanced Stats view)
 
 # Testing dependencies
 pytest==7.4.3

--- a/tests/unit/test_economy_chart.py
+++ b/tests/unit/test_economy_chart.py
@@ -16,6 +16,7 @@ from economy_chart import (
     compute_round_economy,
     pick_squad_team,
     render_economy_chart,
+    warm_up,
 )
 
 
@@ -120,3 +121,13 @@ def test_render_economy_chart_returns_png_or_none():
 def test_render_economy_chart_handles_missing_data():
     assert render_economy_chart(build_match(), None) is None
     assert render_economy_chart({'rounds': []}, 'red') is None
+
+
+def test_warm_up_matches_render_availability():
+    """warm_up() succeeds exactly when matplotlib can be imported."""
+    try:
+        import matplotlib  # noqa: F401
+        have_mpl = True
+    except Exception:
+        have_mpl = False
+    assert warm_up() is have_mpl

--- a/tests/unit/test_economy_chart.py
+++ b/tests/unit/test_economy_chart.py
@@ -1,0 +1,122 @@
+"""Tests for the post-match economy chart data extraction and rendering.
+
+The pure data functions are tested exactly; rendering is tested for graceful
+behaviour whether or not matplotlib is importable on the host.
+"""
+
+import io
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../..')))
+
+from economy_chart import (
+    compute_round_economy,
+    pick_squad_team,
+    render_economy_chart,
+)
+
+
+def build_match():
+    """2v2 match: round 1 Red richer & wins by detonation, round 2 Blue richer
+    & wins by defuse."""
+    return {
+        'metadata': {'map': 'Ascent', 'rounds_played': 2},
+        'players': {'all_players': [
+            {'puuid': 'A1', 'team': 'Red'},
+            {'puuid': 'A2', 'team': 'Red'},
+            {'puuid': 'B1', 'team': 'Blue'},
+            {'puuid': 'B2', 'team': 'Blue'},
+        ]},
+        'teams': {'red': {'has_won': False, 'rounds_won': 1},
+                  'blue': {'has_won': True, 'rounds_won': 1}},
+        'rounds': [
+            {
+                'winning_team': 'Red',
+                'plant_events': {'planted_by': {'puuid': 'A1'}},
+                'defuse_events': {},
+                'player_stats': [
+                    {'player_puuid': 'A1', 'economy': {'loadout_value': 4000}},
+                    {'player_puuid': 'A2', 'economy': {'loadout_value': 4000}},
+                    {'player_puuid': 'B1', 'economy': {'loadout_value': 1000}},
+                    {'player_puuid': 'B2', 'economy': {'loadout_value': 1000}},
+                ],
+            },
+            {
+                'winning_team': 'Blue',
+                'plant_events': {},
+                'defuse_events': {'defused_by': {'puuid': 'B1'}},
+                'player_stats': [
+                    {'player_puuid': 'A1', 'economy': {'loadout_value': 800}},
+                    {'player_puuid': 'A2', 'economy': {'loadout_value': 800}},
+                    {'player_puuid': 'B1', 'economy': {'loadout_value': 5000}},
+                    {'player_puuid': 'B2', 'economy': {'loadout_value': 5000}},
+                ],
+            },
+        ],
+    }
+
+
+def test_compute_round_economy_from_red_perspective():
+    data = compute_round_economy(build_match(), 'red')
+    assert len(data) == 2
+
+    r1 = data[0]
+    assert r1['round'] == 1
+    assert r1['squad_loadout'] == 8000
+    assert r1['enemy_loadout'] == 2000
+    assert r1['diff'] == 6000          # Red richer
+    assert r1['squad_won'] is True
+    assert r1['condition'] == 'plant'  # detonation, spike was planted
+
+    r2 = data[1]
+    assert r2['diff'] == -8400         # Blue richer
+    assert r2['squad_won'] is False
+    assert r2['condition'] == 'defuse'
+
+
+def test_compute_round_economy_perspective_flips_sign():
+    red = compute_round_economy(build_match(), 'red')
+    blue = compute_round_economy(build_match(), 'blue')
+    assert blue[0]['diff'] == -red[0]['diff']
+    assert blue[0]['squad_won'] is False
+
+
+def test_compute_round_economy_no_rounds():
+    assert compute_round_economy({'rounds': []}, 'red') == []
+    assert compute_round_economy(build_match(), '') == []
+
+
+def test_pick_squad_team_prefers_linked_members():
+    # Two linked players sit on Blue -> Blue is the squad.
+    assert pick_squad_team(build_match(), {'B1', 'B2'}) == 'blue'
+    assert pick_squad_team(build_match(), {'A1'}) == 'red'
+
+
+def test_pick_squad_team_falls_back_to_winner():
+    # Nobody linked -> fall back to the match winner (Blue won here).
+    assert pick_squad_team(build_match(), set()) == 'blue'
+
+
+def test_render_economy_chart_returns_png_or_none():
+    """With matplotlib present we get a non-empty PNG; without it, None."""
+    result = render_economy_chart(build_match(), 'red')
+    try:
+        import matplotlib  # noqa: F401
+        have_mpl = True
+    except Exception:
+        have_mpl = False
+
+    if have_mpl:
+        assert isinstance(result, io.BytesIO)
+        head = result.getvalue()[:8]
+        assert head.startswith(b'\x89PNG')
+    else:
+        assert result is None
+
+
+def test_render_economy_chart_handles_missing_data():
+    assert render_economy_chart(build_match(), None) is None
+    assert render_economy_chart({'rounds': []}, 'red') is None


### PR DESCRIPTION
## Summary
Adds a visual round-by-round economy chart to the Advanced Stats view in post-match recaps, showing the loadout-value differential between the squad and enemy team. The chart renders as a PNG with green/red fill areas and includes round outcome markers (elimination, spike detonation, defuse).

## Key Changes
- **economy_chart.py** (new): Core module for economy chart data extraction and rendering
  - `pick_squad_team()`: Determines which team to display from (prefers team with linked squad members, falls back to match winner)
  - `compute_round_economy()`: Extracts per-round loadout totals and differentials from match data
  - `render_economy_chart()`: Generates PNG chart using matplotlib with Tracker.gg-style visualization
  - Lazy matplotlib import with graceful fallback to text-only display if unavailable

- **match_stats_display.py**: Integrates economy chart into Advanced Stats button callback
  - `_build_economy_chart()`: Runs chart rendering in executor to avoid blocking event loop
  - Sends chart as Discord file attachment when available

- **database.py**: New utility method
  - `get_linked_puuids()`: Returns set of all real PUUIDs linked to Discord users (excludes manual links)

- **tests/unit/test_economy_chart.py** (new): Comprehensive test coverage
  - Tests data extraction logic with perspective flipping
  - Tests team selection logic with linked member preference
  - Tests rendering graceful behavior with/without matplotlib

- **requirements.txt**: Added matplotlib>=3.5.0 dependency

## Implementation Details
- No additional Henrik API calls required—uses existing match payload from Advanced Stats reload
- Uses only `loadout_value` field (the only reliably populated economy metric)
- Chart rendering is CPU-bound and runs in default executor to prevent bot stalls
- Gracefully degrades to text-only scoreboard if matplotlib unavailable or rendering fails
- Color scheme matches Discord dark theme (#101820 background, #3ba55d green, #ed4245 red)
- Round outcome markers mirror Tracker.gg's economy tab icons (✕ elim, ▲ detonation, ▼ defuse)

https://claude.ai/code/session_013LdtVZX7MFxdQUfR6ggrCh