### PR TITLE
Simplify match stats display to use fixed team colors

### DIFF
--- a/economy_chart.py
+++ b/economy_chart.py
@@ -123,7 +123,11 @@ def compute_round_economy(match: Dict[str, Any],
 _CONDITION_MARKER = {'elim': 'x', 'plant': '^', 'defuse': 'v'}
 
 _BG = '#101820'
-_GREEN = '#3ba55d'
+# Sides keep their fixed Valorant identity: blue team is always blue, red team
+# is always red. The chart plots the blue team's loadout advantage, so positive
+# (blue richer) fills blue and negative (red richer) fills red — no need to work
+# out which side the squad was on.
+_BLUE = '#3b82f6'
 _RED = '#ed4245'
 _GRID = '#2b3543'
 _TEXT = '#c8d0da'
@@ -138,7 +142,10 @@ def render_economy_chart(match: Dict[str, Any],
     """
     if not squad_team:
         return None
-    data = compute_round_economy(match, squad_team)
+    # The chart is drawn in absolute team terms (blue vs red) rather than from
+    # the squad's perspective, so colours always mean the same side. squad_team
+    # is still required as the "we have a team to anchor on" guard.
+    data = compute_round_economy(match, 'blue')
     if not data:
         return None
 
@@ -156,36 +163,36 @@ def render_economy_chart(match: Dict[str, Any],
         diff_k = [d['diff'] / 1000 for d in data]
 
         teams = match.get('teams', {})
-        squad_team = squad_team.lower()
-        enemy_team = next((c for c in teams if c.lower() != squad_team), None)
-        squad_rounds = teams.get(squad_team, {}).get('rounds_won', 0)
-        enemy_rounds = (teams.get(enemy_team, {}).get('rounds_won', 0)
-                        if enemy_team else 0)
+        blue_rounds = teams.get('blue', {}).get('rounds_won', 0)
+        red_rounds = teams.get('red', {}).get('rounds_won', 0)
         map_name = match.get('metadata', {}).get('map', 'Unknown')
 
         fig, ax = plt.subplots(figsize=(9, 3.6), dpi=110)
         fig.patch.set_facecolor(_BG)
         ax.set_facecolor(_BG)
 
+        # diff is the blue team's loadout advantage, so positive fills blue and
+        # negative fills red.
         ax.fill_between(rounds, diff_k, 0, where=[v >= 0 for v in diff_k],
-                        interpolate=True, color=_GREEN, alpha=0.45)
+                        interpolate=True, color=_BLUE, alpha=0.45)
         ax.fill_between(rounds, diff_k, 0, where=[v <= 0 for v in diff_k],
                         interpolate=True, color=_RED, alpha=0.45)
         ax.plot(rounds, diff_k, color=_TEXT, linewidth=1.4, zorder=3)
         for d, y in zip(data, diff_k):
             ax.plot(d['round'], y, marker='o', markersize=4, zorder=4,
-                    color=_GREEN if d['diff'] >= 0 else _RED)
+                    color=_BLUE if d['diff'] >= 0 else _RED)
         ax.axhline(0, color=_TEXT, linewidth=1.0, alpha=0.8)
 
-        # Round-outcome strip beneath the plot: green = squad won, red = lost,
-        # marker shape encodes the win condition.
+        # Round-outcome strip beneath the plot, coloured by the winning team
+        # (blue/red); marker shape encodes the win condition. squad_won here is
+        # True when blue won, since the economy is computed from blue's side.
         span = max((abs(v) for v in diff_k), default=1) or 1
         strip_y = -span * 1.25
         for d in data:
             if d['squad_won'] is None:
                 color = _GRID
             else:
-                color = _GREEN if d['squad_won'] else _RED
+                color = _BLUE if d['squad_won'] else _RED
             ax.scatter(d['round'], strip_y, s=46, zorder=5, color=color,
                        marker=_CONDITION_MARKER.get(d['condition'], 'x'),
                        linewidths=1.4)
@@ -202,11 +209,11 @@ def render_economy_chart(match: Dict[str, Any],
 
         ax.set_title(
             f"Economy — {map_name}   "
-            f"Squad {squad_rounds} : {enemy_rounds} Enemy",
+            f"Blue {blue_rounds} : {red_rounds} Red",
             color=_TEXT, fontsize=11, fontweight='bold', pad=10)
         ax.set_ylabel("Loadout advantage", color=_TEXT, fontsize=8)
         fig.text(0.5, 0.005,
-                 "▲ green = squad richer · ▼ red = enemy richer    "
+                 "▲ blue = blue richer · ▼ red = red richer    "
                  "strip: ✕ elim · ▲ detonation · ▼ defuse",
                  color=_TEXT, fontsize=6.5, alpha=0.75, ha='center')
 

--- a/match_stats_display.py
+++ b/match_stats_display.py
@@ -124,6 +124,7 @@ _BLUE = "[1;34m"        # blue team
 _RED = "[1;31m"         # red team
 
 _NAME_W = 14
+_AGENT_W = 9  # widest agent name (Brimstone) fits without truncation
 # (header, key, width, higher_is_better)
 _COLS = [
     ("ACS", 'acs', 4, True),
@@ -184,12 +185,13 @@ def build_advanced_scoreboard(match: Dict[str, Any]) -> str:
         name = player.get('name', 'Unknown')
         tag = player.get('tag', '')
         stats['name'] = f"{name}#{tag}" if tag else name
+        stats['agent'] = player.get('character', '') or ''
         rows.append((stats, (player.get('team') or '').lower()))
 
     game_best = {key: max((r[key] for r, _ in rows), default=0)
                  for _, key, _, hib in _COLS if hib}
 
-    header = "Player".ljust(_NAME_W) + "".join(
+    header = "Player".ljust(_NAME_W) + "Agent".ljust(_AGENT_W) + "".join(
         h.rjust(w + 1) for h, _, w, _ in _COLS)
 
     lines = [f"{_HDR}{header}{_RESET}"]
@@ -215,6 +217,7 @@ def build_advanced_scoreboard(match: Dict[str, Any]) -> str:
 
         for r in members:
             cells = _truncate(r['name'], _NAME_W).ljust(_NAME_W)
+            cells += _truncate(r.get('agent', ''), _AGENT_W).ljust(_AGENT_W)
             cells += "".join(
                 " " + _cell(key, r[key], w, hib, game_best, team_best)
                 for _, key, w, hib in _COLS)

--- a/match_stats_display.py
+++ b/match_stats_display.py
@@ -32,69 +32,33 @@ logger = logging.getLogger(__name__)
 _HALF_LENGTH = 12  # standard competitive half
 
 
-def _round_attacking_team(round_data: Dict[str, Any],
-                          puuid_team: Dict[str, str]) -> Optional[str]:
-    """The team on attack for a round, inferred from who planted the spike.
+def build_round_flow(match: Dict[str, Any]) -> str:
+    """Numbered round-by-round strip coloured by the team that won each round.
 
-    Only the attacking side can plant, so the planter's team is the attacker.
-    Returns None for rounds with no plant (e.g. a full eliminate)."""
-    planted_by = (round_data.get('plant_events') or {}).get('planted_by') or {}
-    puuid = planted_by.get('puuid')
-    if puuid and puuid in puuid_team:
-        return puuid_team[puuid]
-    return (planted_by.get('team') or '').lower() or None
-
-
-def build_round_flow(match: Dict[str, Any], team_color: str) -> str:
-    """Numbered, colour-coded round-by-round strip from the squad's view.
-
-    Each round shows its number, coloured green when the squad won it and red
-    when they lost, rendered in a monospace ``ansi`` block so the numbers line
-    up and you can tell exactly which round was which. Each regulation half is
-    tagged ATK/DEF (inferred from who planted the spike) and rows wrap per half
-    (and again for overtime). Returns "" when round data is missing.
+    Blue numbers are rounds the blue team won, red numbers are rounds the red
+    team won — the two fixed Valorant sides, so there's no squad-perspective
+    detection. Rendered in a monospace ``ansi`` block so the numbers line up,
+    wrapped every regulation half. Returns "" when round data is missing.
     """
     rounds = match.get('rounds', [])
-    if not rounds or not team_color:
+    if not rounds:
         return ""
-
-    all_players = match.get('players', {}).get('all_players', [])
-    puuid_team = {p.get('puuid'): (p.get('team') or '').lower()
-                  for p in all_players if p.get('puuid')}
-
-    outcomes = []  # (round_number, won | None)
-    for i, rd in enumerate(rounds, start=1):
-        winner = (rd.get('winning_team') or '').lower()
-        outcomes.append((i, (winner == team_color) if winner else None))
 
     lines = []
     total = len(rounds)
     for start in range(0, total, _HALF_LENGTH):
         end = min(start + _HALF_LENGTH, total)
-
-        # Side tag. Sides hold for a regulation half but swap every round in
-        # overtime, so only the two regulation halves get an ATK/DEF label.
-        if start < 2 * _HALF_LENGTH:
-            attacker = next((t for t in (_round_attacking_team(rounds[i], puuid_team)
-                                         for i in range(start, end)) if t), None)
-            if attacker:
-                tag = (f"{_ATK}ATK{_RESET}" if attacker == team_color
-                       else f"{_DEF}DEF{_RESET}")
-            else:
-                tag = "  ?"
-        else:
-            tag = f"{_HDR} OT{_RESET}"
-
         cells = []
-        for number, won in outcomes[start:end]:
-            label = f"{number:>2}"
-            if won is None:
-                cells.append(label)
-            elif won:
-                cells.append(f"{_WIN}{label}{_RESET}")
+        for i in range(start, end):
+            label = f"{i + 1:>2}"
+            winner = (rounds[i].get('winning_team') or '').lower()
+            if winner == 'blue':
+                cells.append(f"{_BLUE}{label}{_RESET}")
+            elif winner == 'red':
+                cells.append(f"{_RED}{label}{_RESET}")
             else:
-                cells.append(f"{_LOSS}{label}{_RESET}")
-        lines.append(f"{tag} │ " + " ".join(cells))
+                cells.append(label)
+        lines.append(" ".join(cells))
 
     return "```ansi\n" + "\n".join(lines) + "\n```"
 
@@ -153,12 +117,11 @@ _RESET = "[0m"
 _BEST_GAME = "[1;33m"   # bold yellow - best in the whole match
 _BEST_TEAM = "[0;36m"   # cyan - best on the team
 _HDR = "[1;37m"         # bold white header
-_WIN = "[0;32m"         # green team label
-_LOSS = "[0;31m"        # red team label
-
-# Round-flow side tags reuse the highlight palette: yellow attack, cyan defense.
-_ATK = _BEST_GAME
-_DEF = _BEST_TEAM
+# Sides are coloured by their fixed Valorant identity: blue team always
+# blue, red team always red — used for both the team headers and the
+# round-flow strip, so no squad-side detection is needed.
+_BLUE = "[1;34m"        # blue team
+_RED = "[1;31m"         # red team
 
 _NAME_W = 14
 # (header, key, width, higher_is_better)
@@ -247,7 +210,8 @@ def build_advanced_scoreboard(match: Dict[str, Any]) -> str:
         won = teams.get(tcol, {}).get('has_won', False)
         label = f"{tcol.title() or 'Team'} — {team_rounds(tcol)}" + (" 🏆" if won else "")
         lines.append("")
-        lines.append(f"{_WIN if won else _LOSS}{label}{_RESET}")
+        team_color = _BLUE if tcol == "blue" else _RED if tcol == "red" else _HDR
+        lines.append(f"{team_color}{label}{_RESET}")
 
         for r in members:
             cells = _truncate(r['name'], _NAME_W).ljust(_NAME_W)
@@ -259,7 +223,14 @@ def build_advanced_scoreboard(match: Dict[str, Any]) -> str:
     body = "\n".join(lines)
     title = f"📊 **Advanced Match Stats** — {metadata.get('map', 'Unknown')}"
     legend = "🟡 best in match · 🔵 best on team"
-    return f"{title}\n```ansi\n{body}\n```\n_{legend}_"
+    sections = [f"{title}\n```ansi\n{body}\n```\n_{legend}_"]
+
+    # Round-by-round flow, coloured by the team that won each round.
+    flow = build_round_flow(match)
+    if flow:
+        sections.append(f"**Round flow**\n{flow}_🟦 Blue · 🟥 Red_")
+
+    return "\n".join(sections)
 
 
 # --- persistent reveal button ----------------------------------------------

--- a/match_stats_display.py
+++ b/match_stats_display.py
@@ -106,6 +106,7 @@ def player_display_stats(match: Dict[str, Any], player_data: Dict[str, Any],
         'acs': round(score / rounds) if rounds else 0,
         'adr': round(damage / rounds) if rounds else 0,
         'kd': kills / deaths if deaths else float(kills),
+        'kda': (kills + assists) / deaths if deaths else float(kills + assists),
         'hs': hs, 'kast': kast,
         'fk': first_kills, 'fd': first_deaths, 'mk': multikills,
     }
@@ -132,6 +133,7 @@ _COLS = [
     ("D", 'deaths', 3, False),
     ("A", 'assists', 3, True),
     ("K/D", 'kd', 4, True),
+    ("KDA", 'kda', 4, True),
     ("ADR", 'adr', 4, True),
     ("HS%", 'hs', 5, True),
     ("KAST", 'kast', 5, True),
@@ -146,7 +148,7 @@ def _truncate(text: str, width: int) -> str:
 
 
 def _format_value(key: str, value: Any) -> str:
-    if key == 'kd':
+    if key in ('kd', 'kda'):
         return f"{value:.1f}"
     if key in ('hs', 'kast'):
         return f"{value}%"

--- a/match_tracker.py
+++ b/match_tracker.py
@@ -424,14 +424,12 @@ class MatchTracker:
                 entries.append((display_name, pstats, rank_str, ""))
                 untracked_count += 1
 
-        top_acs = max((s['acs'] for _, s, _, _ in entries), default=0)
         member_list = []
         for display_name, s, rank_str, rankup_str in entries:
-            crown = "👑 " if top_acs and s['acs'] == top_acs else ""
             kda = f"{s['kills']}/{s['deaths']}/{s['assists']}"
             # ACS/ADR live in the Advanced Stats popup — the per-player recap
             # line stays lean with just K/D/A and rank to cut the noise.
-            member_list.append(f"• {crown}**{display_name}**: {kda}{rank_str}{rankup_str}")
+            member_list.append(f"• **{display_name}**: {kda}{rank_str}{rankup_str}")
 
         # One-line squad roll-up above the per-player lines.
         if entries:

--- a/match_tracker.py
+++ b/match_tracker.py
@@ -429,8 +429,9 @@ class MatchTracker:
         for display_name, s, rank_str, rankup_str in entries:
             crown = "👑 " if top_acs and s['acs'] == top_acs else ""
             kda = f"{s['kills']}/{s['deaths']}/{s['assists']}"
-            extra = f" · {s['acs']} ACS · {s['adr']} ADR" if (s['acs'] or s['adr']) else ""
-            member_list.append(f"• {crown}**{display_name}**: {kda}{extra}{rank_str}{rankup_str}")
+            # ACS/ADR live in the Advanced Stats popup — the per-player recap
+            # line stays lean with just K/D/A and rank to cut the noise.
+            member_list.append(f"• {crown}**{display_name}**: {kda}{rank_str}{rankup_str}")
 
         # One-line squad roll-up above the per-player lines.
         if entries:

--- a/match_tracker.py
+++ b/match_tracker.py
@@ -9,7 +9,6 @@ from utils import log_error, format_time_ago, parse_henrik_timestamp
 from context_manager import context_manager
 from database import database_manager
 from match_stats_display import (
-    build_round_flow,
     player_display_stats,
     recap_view,
 )
@@ -382,16 +381,8 @@ class MatchTracker:
                 inline=False
             )
 
-        # Round-by-round win/loss flow, shown right under the result so the
-        # game's story reads top-to-bottom (green = round won, red = lost).
-        if have_result:
-            flow = build_round_flow(match, team_color)
-            if flow:
-                embed.add_field(
-                    name="🔄",
-                    value=flow,
-                    inline=False
-                )
+        # The round-by-round flow now lives in the Advanced Stats popup so the
+        # overview stays focused on the result and the squad.
 
         # Add Discord members who played. Each line carries K/D/A plus the two
         # most useful per-round numbers (ACS, ADR); the top ACS in the squad

--- a/tests/unit/test_match_stats_display.py
+++ b/tests/unit/test_match_stats_display.py
@@ -39,39 +39,22 @@ def _match():
 
 # --- round flow -------------------------------------------------------------
 
-def test_round_flow_numbers_rounds_and_colours_by_outcome():
-    flow = msd.build_round_flow(_match(), 'red')
+def test_round_flow_numbers_rounds_and_colours_by_winning_team():
+    flow = msd.build_round_flow(_match())
     # Rendered as a monospace ansi block with round numbers
     assert flow.startswith('```ansi')
     assert ' 1' in flow and '13' in flow
-    # Round 1 (a Red win) is green; round 3 (a Blue win) is red, from red's view
-    assert f'{msd._WIN} 1{msd._RESET}' in flow
-    assert f'{msd._LOSS} 3{msd._RESET}' in flow
+    # Coloured by the team that won the round, not the squad's perspective:
+    # round 1 (a Red win) is red, round 3 (a Blue win) is blue.
+    assert f'{msd._RED} 1{msd._RESET}' in flow
+    assert f'{msd._BLUE} 3{msd._RESET}' in flow
     # Wraps to a second row after the first half (more than 12 rounds)
     assert flow.count('\n') >= 3
 
 
-def test_round_flow_labels_attack_and_defense_halves():
-    flow = msd.build_round_flow(_match(), 'red')
-    lines = [l for l in flow.splitlines() if '│' in l]
-    # Red planted first half -> ATK; Blue planted second half -> Red on DEF
-    assert 'ATK' in lines[0]
-    assert 'DEF' in lines[1]
-
-
-def test_round_flow_unknown_side_when_no_plants():
-    match = _match()
-    for rd in match['rounds']:
-        rd.pop('plant_events', None)
-    flow = msd.build_round_flow(match, 'red')
-    # No plant data -> side can't be inferred, shown as '?'
-    assert '?' in flow
-    assert 'ATK' not in flow and 'DEF' not in flow
-
-
-def test_round_flow_empty_without_rounds_or_team():
-    assert msd.build_round_flow({'rounds': []}, 'red') == ""
-    assert msd.build_round_flow(_match(), '') == ""
+def test_round_flow_empty_without_rounds():
+    assert msd.build_round_flow({'rounds': []}) == ""
+    assert msd.build_round_flow({}) == ""
 
 
 # --- per-player display stats ----------------------------------------------


### PR DESCRIPTION
## Summary
Refactored match stats display to use fixed Valorant team colors (blue/red) instead of squad-perspective coloring. This simplifies the UI by removing the need to track which side the squad was on, making the display more consistent and easier to understand.

## Key Changes

**match_stats_display.py:**
- Removed `_round_attacking_team()` function and squad-perspective logic from `build_round_flow()`
- Simplified `build_round_flow()` to color rounds by the team that won (blue/red) rather than squad perspective
- Removed ATK/DEF side labels and the `team_color` parameter from `build_round_flow()`
- Added `kda` (kills+assists/deaths) stat to player display stats
- Updated color constants: replaced `_WIN`/`_LOSS` with `_BLUE`/`_RED` for absolute team identity
- Added agent name display to the advanced scoreboard with `_AGENT_W` width constant
- Integrated round-flow visualization into the advanced stats popup with team color legend
- Updated team labels in scoreboard to use fixed team colors instead of win/loss indicators

**economy_chart.py:**
- Changed color scheme from green/red to blue/red to match fixed team identity
- Renamed `_GREEN` to `_BLUE` and updated all references
- Simplified `render_economy_chart()` to always compute economy from blue team's perspective
- Updated chart title and legend to show "Blue vs Red" instead of "Squad vs Enemy"
- Removed squad-team perspective detection from the chart rendering

**match_tracker.py:**
- Removed `build_round_flow()` import (no longer needed in match embed)
- Removed round-flow visualization from the main match embed to reduce clutter
- Simplified per-player recap line to show only K/D/A and rank (removed ACS/ADR)
- Removed "best ACS" crown indicator from player display
- Added note that detailed stats now live in the Advanced Stats popup

**tests/unit/test_match_stats_display.py:**
- Updated test to verify round coloring by winning team (blue/red) instead of squad perspective
- Removed tests for ATK/DEF side labels and plant-based side detection
- Simplified test expectations to match new absolute team color scheme

## Implementation Details

- The round-flow visualization now appears in the Advanced Stats popup rather than the main match embed, keeping the overview focused
- All team-related displays consistently use blue for the blue team and red for the red team, eliminating the need for squad-perspective detection
- The economy chart plots blue team's loadout advantage with blue/red fills, making the visualization clearer and more intuitive
- Added KDA stat alongside K/D for more comprehensive player performance metrics
- Agent names are now displayed in the scoreboard for better context on player selections

https://claude.ai/code/session_017h4v8oSS6KpCHvdkqLbqAB