### PR TITLE
Slim down the Advanced Stats recap to map name + table

### DIFF
--- a/match_stats_display.py
+++ b/match_stats_display.py
@@ -27,42 +27,6 @@ from utils import log_error
 
 logger = logging.getLogger(__name__)
 
-# --- round flow -------------------------------------------------------------
-
-_HALF_LENGTH = 12  # standard competitive half
-
-
-def build_round_flow(match: Dict[str, Any]) -> str:
-    """Numbered round-by-round strip coloured by the team that won each round.
-
-    Blue numbers are rounds the blue team won, red numbers are rounds the red
-    team won — the two fixed Valorant sides, so there's no squad-perspective
-    detection. Rendered in a monospace ``ansi`` block so the numbers line up,
-    wrapped every regulation half. Returns "" when round data is missing.
-    """
-    rounds = match.get('rounds', [])
-    if not rounds:
-        return ""
-
-    lines = []
-    total = len(rounds)
-    for start in range(0, total, _HALF_LENGTH):
-        end = min(start + _HALF_LENGTH, total)
-        cells = []
-        for i in range(start, end):
-            label = f"{i + 1:>2}"
-            winner = (rounds[i].get('winning_team') or '').lower()
-            if winner == 'blue':
-                cells.append(f"{_BLUE}{label}{_RESET}")
-            elif winner == 'red':
-                cells.append(f"{_RED}{label}{_RESET}")
-            else:
-                cells.append(label)
-        lines.append(" ".join(cells))
-
-    return "```ansi\n" + "\n".join(lines) + "\n```"
-
-
 # --- per-player display stats ----------------------------------------------
 
 def _rounds_played(match: Dict[str, Any]) -> int:
@@ -226,16 +190,10 @@ def build_advanced_scoreboard(match: Dict[str, Any]) -> str:
             lines.append(cells)
 
     body = "\n".join(lines)
-    title = f"📊 **Advanced Match Stats** — {metadata.get('map', 'Unknown')}"
-    legend = "🟡 best in match · 🔵 best on team"
-    sections = [f"{title}\n```ansi\n{body}\n```\n_{legend}_"]
-
-    # Round-by-round flow, coloured by the team that won each round.
-    flow = build_round_flow(match)
-    if flow:
-        sections.append(f"**Round flow**\n{flow}_🟦 Blue · 🟥 Red_")
-
-    return "\n".join(sections)
+    # Just the map name + the table; the recap headline and the economy chart
+    # (which carries its own title) supply the rest of the context.
+    title = f"**{metadata.get('map', 'Unknown')}**"
+    return f"{title}\n```ansi\n{body}\n```"
 
 
 # --- persistent reveal button ----------------------------------------------

--- a/tests/unit/test_match_stats_display.py
+++ b/tests/unit/test_match_stats_display.py
@@ -37,26 +37,6 @@ def _match():
     }
 
 
-# --- round flow -------------------------------------------------------------
-
-def test_round_flow_numbers_rounds_and_colours_by_winning_team():
-    flow = msd.build_round_flow(_match())
-    # Rendered as a monospace ansi block with round numbers
-    assert flow.startswith('```ansi')
-    assert ' 1' in flow and '13' in flow
-    # Coloured by the team that won the round, not the squad's perspective:
-    # round 1 (a Red win) is red, round 3 (a Blue win) is blue.
-    assert f'{msd._RED} 1{msd._RESET}' in flow
-    assert f'{msd._BLUE} 3{msd._RESET}' in flow
-    # Wraps to a second row after the first half (more than 12 rounds)
-    assert flow.count('\n') >= 3
-
-
-def test_round_flow_empty_without_rounds():
-    assert msd.build_round_flow({'rounds': []}) == ""
-    assert msd.build_round_flow({}) == ""
-
-
 # --- per-player display stats ----------------------------------------------
 
 def test_player_display_stats_falls_back_to_basic_scoreboard():


### PR DESCRIPTION
Follow-up cleanup to the post-match recap (PR #69 is already merged).

## What changed
Trims the **Advanced Stats** popup down to just the map name and the scoreboard table, since the surrounding context is already covered elsewhere:

- Removed the "📊 Advanced Match Stats" title (kept just the map name, e.g. `**Pearl**`)
- Removed the round-by-round flow strip
- Removed the "🟡 best in match · 🔵 best on team" legend
- Removed the "🟦 Blue · 🟥 Red" square legend

The economy chart still follows the table and carries its own title (`Economy — Pearl   Blue 13 : 10 Red`), so no context is lost.

Also dropped the now-unused `build_round_flow` helper and its tests.

## Result
```
**Pearl**
```ansi
Player        Agent      ACS   K   D   A  K/D  KDA  ADR  HS%  KAST  FK  FD  MK
...
```
```
(economy chart image attached below the table, as before)

## Testing
`pytest tests/unit/test_match_stats_display.py tests/unit/test_economy_chart.py` — all pass.

https://claude.ai/code/session_017h4v8oSS6KpCHvdkqLbqAB

---
_Generated by [Claude Code](https://claude.ai/code/session_017h4v8oSS6KpCHvdkqLbqAB)_