### PR TITLE
Run updates every 15 min, session-safe and crash-safe

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,8 @@ coverage.xml
 *.cover
 .hypothesis/
 .bot_health
+.active_session
+.last_update_check
 # OS files
 .DS_Store
 .DS_Store?

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,11 +30,14 @@ pip install -r requirements.txt
 python3 bot.py  # Linux/Mac
 py -3 .\bot.py  # Windows
 
-# Run in production (using screen with auto-update)
+# Production: systemd (preferred) — installs the bot service + every-15-min update timer
+sudo ./setup_systemd.sh           # (re)install units; also activates a new update cadence
+
+# Run in production (legacy screen path)
 ./run_python_script.sh
 
 # CI/CD Auto-Update & Monitoring Commands
-./setup_auto_update.sh            # Setup auto-start, monitoring & daily updates
+./setup_auto_update.sh            # Legacy cron: auto-start, monitoring & 15-min updates
 ./run_python_script.sh --start         # Start bot manually
 ./run_python_script.sh --monitor       # Run health check manually
 ./run_python_script.sh --force-update  # Force immediate update check
@@ -141,6 +144,47 @@ Production runs on a low-RAM Raspberry Pi (~921 MiB) on **Raspberry Pi OS Bullse
 Also: numpy's piwheels wheel links system OpenBLAS — `setup_pi_env.sh` installs `libopenblas0 libgfortran5`. Swap is raised to 1 GB as an OOM safety net.
 
 **Gotcha:** if charts stop rendering, check `venv/bin/python` is still 3.9 — a stray `python3.11 -m venv` reintroduces the glibc problem. matplotlib imports are guarded (`try/except` in `economy_chart.py`), so a broken matplotlib only degrades the recap chart to text; it never crashes the bot.
+
+## Auto-Update & Crash-Safe Sessions
+
+ShootyBot self-updates from GitHub and survives restarts without losing an
+in-progress session. Two cooperating mechanisms:
+
+### Update cadence (systemd)
+- **`deploy/shootybot-update.timer`** fires **every 15 minutes** (`OnCalendar=*:0/15`)
+  → `shootybot-update.service` → `run_python_script.sh --force-update`. (The
+  legacy non-systemd path in `setup_auto_update.sh` installs equivalent
+  `*/15` cron jobs.)
+- **`apply_updates()`** in `run_python_script.sh`:
+  1. **Session guard** — reads the `.active_session` marker the bot writes; if a
+     session is in progress it **defers** (does NOT pull), retrying next cycle so
+     players are never interrupted.
+  2. `git pull`, then **self-deploy**: if the pull changed `deploy/` or
+     `setup_systemd.sh`, reinstall the units (`sudo -n ./setup_systemd.sh <owner>`).
+  3. Restart systemd-aware: `sudo -n systemctl restart shootybot.service`, falling
+     back to signaling the process (systemd `Restart=` relaunches it), then to the
+     legacy screen path.
+- **Drift self-heal** — `ensure_systemd_units_current()` runs on every
+  `--force-update` and reinstalls units when the installed timer differs from the
+  repo's (this is how the 5 AM→15 min change converges on its own after the older
+  updater first pulls it). **Bootstrap:** to activate a *new cadence* instantly
+  (instead of waiting for the next self-heal run), run once: `sudo ./setup_systemd.sh`.
+  Reinstalling units does NOT restart the bot, so it's safe mid-session.
+- Privilege: the update service runs as the bot user; `sudo -n` is used
+  best-effort. Without passwordless sudo it logs the one command to run by hand;
+  the process-signal restart fallback needs no sudo.
+
+### Session persistence (restart-safe)
+- Party membership (who reacted 👍/5️⃣/✅) is **never stored in the DB** — the
+  reactions on the bot's session message ARE the source of truth. On startup
+  `restore_party_state_from_reactions()` (called from `on_ready`) re-reads those
+  reactions for every channel with a saved `current_st_message_id` and rebuilds
+  the soloq/fullstack/ready sets, then re-links the still-open session via
+  `database.get_open_session_for_channel()` so `/stend` and the recap still work.
+- **Reactions use *raw* events** (`on_raw_reaction_add/remove`), NOT the
+  cache-backed `on_reaction_add/remove`. The cached variants only fire when the
+  reacted message is in the bot's in-memory cache, which is empty after a restart
+  — that was why reactions silently stopped updating the party post-restart.
 
 ## MCP (Model Context Protocol) Servers
 
@@ -287,10 +331,11 @@ python3 test_database_fast.py
 - **Command callback testing**: Test hybrid command callbacks directly using `.callback(cog, ctx)`
 
 ### Production Deployment:
-- **Process management**: Use screen/tmux for persistent bot processes
+- **Process management**: systemd (`shootybot.service`) is the production path; screen/tmux is the legacy fallback
+- **Auto-update**: every 15 minutes, session-aware and self-deploying — see "Auto-Update & Crash-Safe Sessions" above
 - **Log rotation**: Implement log rotation to prevent disk space issues
 - **Environment isolation**: Use virtual environments in production
-- **Graceful shutdown**: Handle SIGTERM/SIGINT for clean bot shutdown
+- **Graceful shutdown**: Handle SIGTERM/SIGINT for clean bot shutdown (state also rebuilds from reactions on restart)
 
 ### Debugging Tips:
 - **Enable debug logging**: Set LOG_LEVEL=DEBUG for detailed operation logs

--- a/bot.py
+++ b/bot.py
@@ -10,7 +10,7 @@ import asyncio
 from config import BOT_TOKEN, COMMAND_PREFIX, LOG_LEVEL, MESSAGES, APP_VERSION, DB_MATCH_STORAGE_WARN_MB, DB_PLAYER_STATS_WARN_MB
 from context_manager import context_manager
 from handlers.message_formatter import DEFAULT_MSG
-from handlers.reaction_handler import add_react_options
+from handlers.reaction_handler import add_react_options, restore_party_state_from_reactions
 from match_tracker import get_match_tracker
 from match_stats_display import AdvancedStatsButton
 from economy_chart import warm_up as warm_up_economy_chart
@@ -36,15 +36,43 @@ class ShootyBot(commands.Bot):
         self.match_tracker: Optional[object] = None
         self._cogs_loaded: bool = False
         self.health_check_file = ".bot_health"
+        # Marker read by the auto-updater (run_python_script.sh) so it can defer
+        # a restart while a session is in progress and not interrupt players.
+        self.active_session_file = ".active_session"
+
+    def count_active_sessions(self) -> int:
+        """Count channels with a session currently in progress.
+
+        A session is "in progress" when it has a tracked session id or any
+        queued members. Used to decide whether an auto-update may restart now.
+        """
+        active = 0
+        for context in context_manager.contexts.values():
+            has_session = bool(getattr(context, "current_session_id", None))
+            has_members = bool(
+                context.bot_soloq_user_set or context.bot_fullstack_user_set
+            )
+            if has_session or has_members:
+                active += 1
+        return active
 
     @tasks.loop(minutes=2)
     async def health_check_task(self) -> None:
-        """Update health check file every 2 minutes."""
+        """Update health + active-session marker files every 2 minutes."""
+        now = str(int(time.time()))
         try:
             with open(self.health_check_file, "w") as f:
-                f.write(str(int(time.time())))
+                f.write(now)
         except Exception as e:
             logging.error(f"Failed to update health check file: {e}")
+
+        # Write "<active_count> <timestamp>" so the updater can both read the
+        # count and tell whether the marker is fresh (bot still alive).
+        try:
+            with open(self.active_session_file, "w") as f:
+                f.write(f"{self.count_active_sessions()} {now}")
+        except Exception as e:
+            logging.error(f"Failed to update active-session file: {e}")
 
     @health_check_task.before_loop
     async def before_health_check(self) -> None:
@@ -126,6 +154,15 @@ class ShootyBot(commands.Bot):
 
         # Sync commands
         await self.sync_commands()
+
+        # Rebuild any in-progress party state from Discord. Membership lives in
+        # the session message's reactions (not the DB), so after a restart we
+        # re-read those reactions instead of losing the active session.
+        try:
+            await restore_party_state_from_reactions(self)
+            await self.update_status_with_queue_count()
+        except Exception as e:
+            log_error("restoring party state on startup", e)
 
         # Start match tracker
         await self.start_match_tracker()

--- a/database.py
+++ b/database.py
@@ -644,6 +644,31 @@ class DatabaseManager:
             finally:
                 conn.close()
     
+    def get_open_session_for_channel(self, channel_id: int) -> Optional[Dict[str, Any]]:
+        """Return the most recent still-open (not yet ended) session for a channel.
+
+        Used on startup to re-link a channel's in-progress session after a bot
+        restart, so commands like ``/stend`` and the recap still work. A session
+        is "open" when its ``end_time`` is NULL.
+        """
+        with self._lock:
+            conn = self._get_connection()
+            try:
+                row = conn.execute("""
+                    SELECT * FROM sessions
+                    WHERE channel_id = ? AND end_time IS NULL
+                    ORDER BY start_time DESC
+                    LIMIT 1
+                """, (channel_id,)).fetchone()
+
+                return dict(row) if row else None
+
+            except Exception as e:
+                logging.error(f"Error getting open session for {channel_id}: {e}")
+                return None
+            finally:
+                conn.close()
+
     # Channel settings methods
     def get_channel_settings(self, channel_id: int) -> Optional[Dict[str, Any]]:
         """Get channel settings"""
@@ -694,7 +719,24 @@ class DatabaseManager:
                 return False
             finally:
                 conn.close()
-    
+
+    def get_all_channel_settings(self) -> List[Dict[str, Any]]:
+        """Return settings rows for every channel the bot has configured.
+
+        Used on startup to find channels with an active party message
+        (``current_st_message_id``) so their state can be rebuilt.
+        """
+        with self._lock:
+            conn = self._get_connection()
+            try:
+                rows = conn.execute("SELECT * FROM channel_settings").fetchall()
+                return [dict(row) for row in rows]
+            except Exception as e:
+                logging.error(f"Error getting all channel settings: {e}")
+                return []
+            finally:
+                conn.close()
+
     # Migration and utility methods
     def migrate_from_json(self, users_file: str, sessions_file: str, channel_file: str) -> bool:
         """Migrate data from existing JSON files"""

--- a/deploy/shootybot-update.timer
+++ b/deploy/shootybot-update.timer
@@ -1,10 +1,15 @@
-# Timer to run the ShootyBot update check daily at 5 AM
+# Timer to run the ShootyBot update check every 15 minutes.
+# The update service itself defers the restart while a session is in progress,
+# so frequent checks never interrupt players.
 
 [Unit]
-Description=Run ShootyBot update check daily
+Description=Run ShootyBot update check every 15 minutes
 
 [Timer]
-OnCalendar=*-*-* 05:00:00
+# At minute 0, 15, 30 and 45 of every hour.
+OnCalendar=*:0/15
+# Catch up on a missed run (e.g. after the Pi was powered off) instead of
+# waiting for the next quarter-hour.
 Persistent=true
 
 [Install]

--- a/handlers/reaction_handler.py
+++ b/handlers/reaction_handler.py
@@ -1,11 +1,17 @@
 import logging
-from typing import Union
+from typing import Optional, Union
 import discord
 from discord.ext import commands
 from context_manager import context_manager
 from handlers.message_formatter import party_status_message
 from data_manager import data_manager
+from database import database_manager
 from config import EMOJI, MESSAGES
+
+# Emojis that join the party and therefore define membership when we rebuild
+# state from a message's reactions after a restart.
+_PARTY_EMOJIS = {EMOJI["THUMBS_UP"], EMOJI["FULL_STACK"], EMOJI["READY"]}
+
 
 async def add_react_options(message: discord.Message) -> None:
     """Add reaction options to a message"""
@@ -14,8 +20,112 @@ async def add_react_options(message: discord.Message) -> None:
     await message.add_reaction(EMOJI["REFRESH"])
     await message.add_reaction(EMOJI["MENTION"])
 
+
+async def restore_party_state_from_reactions(bot: commands.Bot) -> int:
+    """Rebuild in-memory party state from Discord after a restart.
+
+    Party membership (who reacted 👍 / 5️⃣ / ✅) is never stored in the
+    database — the reactions on the bot's session message *are* the source of
+    truth. On startup the bot's message cache is empty, so we walk every
+    channel that has a saved ``current_st_message_id``, re-read its reactions,
+    and repopulate the soloq / fullstack / ready sets. We also re-link the
+    channel's still-open session so ``/stend`` keeps working.
+
+    Returns the number of channels whose state was restored.
+    """
+    restored = 0
+    for settings in database_manager.get_all_channel_settings():
+        message_id = settings.get("current_st_message_id")
+        channel_id = settings.get("channel_id")
+        if not message_id or not channel_id:
+            continue
+
+        channel = bot.get_channel(channel_id)
+        if channel is None:
+            try:
+                channel = await bot.fetch_channel(channel_id)
+            except (discord.NotFound, discord.Forbidden, discord.HTTPException):
+                logging.info(f"Restore: channel {channel_id} unavailable, skipping")
+                continue
+
+        try:
+            message = await channel.fetch_message(message_id)
+        except discord.NotFound:
+            logging.info(f"Restore: session message {message_id} gone in {channel_id}")
+            continue
+        except discord.HTTPException as e:
+            logging.warning(f"Restore: failed to fetch message in {channel_id}: {e}")
+            continue
+
+        # Only restore from our own session messages
+        if message.author.id != bot.user.id:
+            continue
+
+        shooty_context = context_manager.get_context(channel_id)
+        shooty_context.channel = channel
+        shooty_context.current_st_message_id = message_id
+        shooty_context.reset_users()
+
+        try:
+            await _rebuild_users_from_reactions(message, shooty_context, bot)
+        except discord.HTTPException as e:
+            logging.warning(f"Restore: failed reading reactions in {channel_id}: {e}")
+            continue
+
+        # Re-link the still-open session (end_time IS NULL) so /stend & recap work
+        open_session = database_manager.get_open_session_for_channel(channel_id)
+        if open_session:
+            shooty_context.current_session_id = open_session["session_id"]
+
+        member_count = len(
+            shooty_context.bot_soloq_user_set | shooty_context.bot_fullstack_user_set
+        )
+        logging.info(
+            f"Restored party state for channel {channel_id}: "
+            f"{member_count} member(s), session="
+            f"{getattr(shooty_context, 'current_session_id', None)}"
+        )
+        restored += 1
+
+    if restored:
+        logging.info(f"♻️ Restored party state for {restored} channel(s) after restart")
+    return restored
+
+
+async def _rebuild_users_from_reactions(message, shooty_context, bot) -> None:
+    """Repopulate a context's user sets from the reactions on ``message``."""
+    for reaction in message.reactions:
+        emoji = str(reaction.emoji)
+        if emoji not in _PARTY_EMOJIS:
+            continue
+
+        async for user in reaction.users():
+            if user.bot:
+                continue
+            # Prefer the richer guild Member object for voice-presence checks
+            member = user
+            guild = getattr(message.channel, "guild", None)
+            if guild is not None:
+                member = guild.get_member(user.id) or user
+
+            if emoji == EMOJI["THUMBS_UP"]:
+                shooty_context.add_soloq_user(member)
+            elif emoji == EMOJI["FULL_STACK"]:
+                shooty_context.add_fullstack_user(member)
+            elif emoji == EMOJI["READY"]:
+                shooty_context.bot_ready_user_set.add(member)
+
+
 class ReactionHandler(commands.Cog):
-    """Handles all reaction-based interactions"""
+    """Handles all reaction-based interactions.
+
+    Uses *raw* reaction events (``on_raw_reaction_add`` /
+    ``on_raw_reaction_remove``) instead of the cache-backed
+    ``on_reaction_add`` / ``on_reaction_remove``. The cached variants only fire
+    when the reacted message is in the bot's in-memory message cache, which is
+    empty after a restart — so reactions on an existing session message would
+    silently stop updating the party. Raw events fire regardless of the cache.
+    """
 
     def __init__(self, bot: commands.Bot) -> None:
         self.bot = bot
@@ -24,122 +134,145 @@ class ReactionHandler(commands.Cog):
         """Helper method to update party status message"""
         new_message = party_status_message(True, shooty_context)
         await message.edit(content=new_message)
-    
-    @commands.Cog.listener()
-    async def on_reaction_add(self, reaction: discord.Reaction, user: Union[discord.Member, discord.User]) -> None:
-        """Handle when users add reactions"""
-        if user.bot or reaction.message.author != self.bot.user:
-            return
-        
-        channel_id = reaction.message.channel.id
+
+    async def _resolve_reaction(
+        self, payload: discord.RawReactionActionEvent
+    ) -> Optional[tuple]:
+        """Resolve a raw reaction payload to (message, member, shooty_context).
+
+        Returns ``None`` (so the caller bails) when the reaction is the bot's
+        own, isn't on the channel's current session message, or can't be
+        resolved to a real member/message.
+        """
+        # Ignore the bot's own reactions (e.g. the initial option emojis)
+        if payload.user_id == self.bot.user.id:
+            return None
+
+        channel_id = payload.channel_id
         shooty_context = context_manager.get_context(channel_id)
+
+        # Cheap early-out: only the latest session message drives party state,
+        # and this avoids fetching messages for unrelated reactions.
+        if not shooty_context.current_st_message_id:
+            return None
+        if payload.message_id != shooty_context.current_st_message_id:
+            return None
+
+        channel = self.bot.get_channel(channel_id)
+        if channel is None:
+            try:
+                channel = await self.bot.fetch_channel(channel_id)
+            except discord.HTTPException:
+                return None
+
+        # Resolve the member. on_raw_reaction_add gives us payload.member in
+        # guilds; on remove we must look the user up ourselves.
+        member: Optional[Union[discord.Member, discord.User]] = payload.member
+        if member is None:
+            guild = getattr(channel, "guild", None)
+            if guild is not None:
+                member = guild.get_member(payload.user_id)
+            if member is None:
+                try:
+                    member = await self.bot.fetch_user(payload.user_id)
+                except discord.HTTPException:
+                    return None
+
+        if member is None or member.bot:
+            return None
+
+        try:
+            message = await channel.fetch_message(payload.message_id)
+        except discord.HTTPException:
+            return None
+
         # Keep a live channel reference so voice-channel presence can be resolved
-        shooty_context.channel = reaction.message.channel
+        shooty_context.channel = channel
+        return message, member, shooty_context
+
+    @commands.Cog.listener()
+    async def on_raw_reaction_add(self, payload: discord.RawReactionActionEvent) -> None:
+        """Handle when users add reactions (cache-independent)."""
+        resolved = await self._resolve_reaction(payload)
+        if resolved is None:
+            return
+        message, user, shooty_context = resolved
+        emoji = str(payload.emoji)
 
         logging.info(
-            f"Reaction added: {reaction.emoji} by {user.name} in channel {channel_id}"
+            f"Reaction added: {emoji} by {user.name} in channel {payload.channel_id}"
         )
-        
-        # Only handle reactions on the latest shooty message
-        if reaction.message.id != shooty_context.current_st_message_id:
-            logging.info("Ignoring reaction - not on latest shooty message")
-            return
-        
+
         # Handle thumbs up (solo queue)
-        if str(reaction.emoji) == EMOJI["THUMBS_UP"]:
+        if emoji == EMOJI["THUMBS_UP"]:
             shooty_context.add_soloq_user(user)
             logging.info(f"Added {user.name} to solo queue")
-            
-            # Track session participation
             await self._track_session_participation(shooty_context, user)
-
-            await self._update_party_message(reaction.message, shooty_context)
-
-            # Update bot status
+            await self._update_party_message(message, shooty_context)
             await self.bot.update_status_with_queue_count()
-        
+
         # Handle 5️⃣ (fullstack only)
-        elif str(reaction.emoji) == EMOJI["FULL_STACK"]:
+        elif emoji == EMOJI["FULL_STACK"]:
             if not shooty_context.is_soloq_user(user):
                 shooty_context.add_fullstack_user(user)
                 logging.info(f"Added {user.name} to fullstack queue")
-                
-                # Track session participation
                 await self._track_session_participation(shooty_context, user)
-
-                await self._update_party_message(reaction.message, shooty_context)
-
-                # Update bot status
+                await self._update_party_message(message, shooty_context)
                 await self.bot.update_status_with_queue_count()
-        
+
         # Handle ✅ (ready)
-        elif str(reaction.emoji) == EMOJI["READY"]:
+        elif emoji == EMOJI["READY"]:
             shooty_context.bot_ready_user_set.add(user)
             logging.info(f"Marked {user.name} as ready")
+            await self._update_party_message(message, shooty_context)
 
-            await self._update_party_message(reaction.message, shooty_context)
-        
         # Handle 🔄 (refresh)
-        elif str(reaction.emoji) == EMOJI["REFRESH"]:
+        elif emoji == EMOJI["REFRESH"]:
             logging.info("Refresh emoji clicked")
-            await self._refresh_status(reaction.message)
-        
+            await self._refresh_status(message)
+
         # Handle 📣 (mention)
-        elif str(reaction.emoji) == EMOJI["MENTION"]:
+        elif emoji == EMOJI["MENTION"]:
             logging.info("Mention emoji clicked")
-            await self._mention_party(reaction.message)
-    
+            await self._mention_party(message)
+
     @commands.Cog.listener()
-    async def on_reaction_remove(self, reaction: discord.Reaction, user: Union[discord.Member, discord.User]) -> None:
-        """Handle when users remove reactions"""
-        if user.bot or reaction.message.author != self.bot.user:
+    async def on_raw_reaction_remove(self, payload: discord.RawReactionActionEvent) -> None:
+        """Handle when users remove reactions (cache-independent)."""
+        resolved = await self._resolve_reaction(payload)
+        if resolved is None:
             return
-        
-        channel_id = reaction.message.channel.id
-        shooty_context = context_manager.get_context(channel_id)
-        # Keep a live channel reference so voice-channel presence can be resolved
-        shooty_context.channel = reaction.message.channel
+        message, user, shooty_context = resolved
+        emoji = str(payload.emoji)
 
         logging.info(
-            f"Reaction removed: {reaction.emoji} by {user.name} in channel {channel_id}"
+            f"Reaction removed: {emoji} by {user.name} in channel {payload.channel_id}"
         )
-        
-        # Only handle reactions on the latest shooty message
-        if reaction.message.id != shooty_context.current_st_message_id:
-            logging.info("Ignoring reaction removal - not on latest shooty message")
-            return
-        
+
         # Handle thumbs up removal (solo queue)
-        if str(reaction.emoji) == EMOJI["THUMBS_UP"] and shooty_context.is_soloq_user(user):
+        if emoji == EMOJI["THUMBS_UP"] and shooty_context.is_soloq_user(user):
             shooty_context.remove_soloq_user(user)
             # Also remove plus ones when user leaves party
             shooty_context.remove_plus_ones(user)
             logging.info(f"Removed {user.name} from solo queue and cleared their plus ones")
-
-            await self._update_party_message(reaction.message, shooty_context)
-
-            # Update bot status
+            await self._update_party_message(message, shooty_context)
             await self.bot.update_status_with_queue_count()
 
         # Handle 5️⃣ removal (fullstack)
-        elif str(reaction.emoji) == EMOJI["FULL_STACK"] and user in shooty_context.bot_fullstack_user_set:
+        elif emoji == EMOJI["FULL_STACK"] and user in shooty_context.bot_fullstack_user_set:
             shooty_context.remove_fullstack_user(user)
             # Also remove plus ones when user leaves party
             shooty_context.remove_plus_ones(user)
             logging.info(f"Removed {user.name} from fullstack queue and cleared their plus ones")
-
-            await self._update_party_message(reaction.message, shooty_context)
-
-            # Update bot status
+            await self._update_party_message(message, shooty_context)
             await self.bot.update_status_with_queue_count()
-        
+
         # Handle ✅ removal (ready)
-        elif str(reaction.emoji) == EMOJI["READY"] and user in shooty_context.bot_ready_user_set:
+        elif emoji == EMOJI["READY"] and user in shooty_context.bot_ready_user_set:
             shooty_context.bot_ready_user_set.remove(user)
             logging.info(f"Unmarked {user.name} as ready")
+            await self._update_party_message(message, shooty_context)
 
-            await self._update_party_message(reaction.message, shooty_context)
-    
     @commands.Cog.listener()
     async def on_voice_state_update(
         self,
@@ -185,32 +318,32 @@ class ReactionHandler(commands.Cog):
         """Refresh the party status message"""
         channel_id = message.channel.id
         shooty_context = context_manager.get_context(channel_id)
-        
+
         # Create a fake context for the session status command
         ctx = await self.bot.get_context(message)
-        
+
         # Get the session commands cog
         session_cog = self.bot.get_cog('SessionCommands')
         if session_cog:
             await session_cog.session_status(ctx)
-    
+
     async def _mention_party(self, message):
         """Mention all party members"""
         channel_id = message.channel.id
         shooty_context = context_manager.get_context(channel_id)
-        
+
         if not shooty_context.bot_soloq_user_set and not shooty_context.bot_fullstack_user_set:
             await message.channel.send(MESSAGES["NO_MEMBERS"])
             return
-        
+
         mention_message = "".join(
             user.mention + " "
             for user in shooty_context.bot_soloq_user_set.union(shooty_context.bot_fullstack_user_set)
             if not user.bot
         )
-        
+
         await message.channel.send(mention_message)
-    
+
     async def _track_session_participation(self, shooty_context, user):
         """Track user participation in the current session"""
         if hasattr(shooty_context, 'current_session_id') and shooty_context.current_session_id:
@@ -218,12 +351,12 @@ class ReactionHandler(commands.Cog):
             if session:
                 session.add_participant(user.id)
                 data_manager.save_session(session.session_id)
-                
+
                 # Update user stats
                 user_data = data_manager.get_user(user.id)
                 user_data.add_session_to_history(session.session_id)
                 data_manager.save_user(user.id)
-                
+
                 logging.info(f"Tracked participation for {user.name} in session {session.session_id}")
 
 async def setup(bot: commands.Bot) -> None:

--- a/run_python_script.sh
+++ b/run_python_script.sh
@@ -7,9 +7,18 @@
 SCREEN_NAME="shooty"
 LOG_FILE="update.log"
 MONITOR_LOG_FILE="monitor.log"
-UPDATE_CHECK_HOUR=5  # 5 AM
+UPDATE_CHECK_HOUR=5  # 5 AM (only used by the legacy daily fallback path)
 LAST_CHECK_FILE=".last_update_check"
 HEALTH_CHECK_FILE=".bot_health"
+# Marker written by the bot (bot.py) holding "<active_session_count> <epoch>".
+# Used to defer an update-restart while a session is in progress.
+ACTIVE_SESSION_FILE=".active_session"
+# Treat the marker as authoritative only if updated within this many seconds;
+# a stale marker means the bot is down, so there is no session to protect.
+ACTIVE_SESSION_FRESH_SECS=600
+# systemd unit installed by setup_systemd.sh. When present we restart through
+# systemd instead of the legacy screen session.
+SYSTEMD_SERVICE="shootybot.service"
 
 # Get the directory where this script is located
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -44,35 +53,143 @@ check_for_updates() {
     fi
 }
 
+# Returns 0 if a session is currently in progress (so we should NOT restart),
+# 1 otherwise. Reads the marker the bot writes; a missing or stale marker means
+# the bot isn't reporting an active session, so updating is safe.
+bot_has_active_session() {
+    [ -f "${ACTIVE_SESSION_FILE}" ] || return 1
+
+    local content count ts now age
+    content=$(cat "${ACTIVE_SESSION_FILE}" 2>/dev/null)
+    count=$(echo "${content}" | awk '{print $1}')
+    ts=$(echo "${content}" | awk '{print $2}')
+
+    # Bail out (treat as no session) on malformed content
+    [[ "${count}" =~ ^[0-9]+$ ]] || return 1
+    [[ "${ts}" =~ ^[0-9]+$ ]] || return 1
+
+    now=$(date +%s)
+    age=$((now - ts))
+    # Stale marker -> bot is likely down -> nothing to protect
+    if [ "${age}" -gt "${ACTIVE_SESSION_FRESH_SECS}" ]; then
+        return 1
+    fi
+
+    [ "${count}" -gt 0 ]
+}
+
+# True when the bot is managed by the systemd service (production path):
+# systemd is available AND our service unit is actually installed. Checking the
+# unit file directly avoids false positives on screen/cron hosts that happen to
+# run systemd but never installed our service.
+under_systemd() {
+    command -v systemctl >/dev/null 2>&1 && [ -f "/etc/systemd/system/${SYSTEMD_SERVICE}" ]
+}
+
+# Reinstall the systemd units from the (freshly pulled) deploy/ directory so a
+# change to the timer cadence or service definition actually takes effect. This
+# is what lets THIS change (5 AM -> every 15 min) auto-deploy on the next pull.
+# Needs root: attempted non-interactively (sudo -n); if unavailable we log the
+# one command an operator must run once.
+reinstall_systemd_units() {
+    local bot_user
+    bot_user=$(stat -c %U "${SCRIPT_DIR}" 2>/dev/null || echo "${USER}")
+
+    log "🧩 Reinstalling systemd units (deploy files changed)..."
+    if [ "$(id -u)" -eq 0 ]; then
+        ./setup_systemd.sh "${bot_user}" >>"${LOG_FILE}" 2>&1 && return 0
+    elif sudo -n true 2>/dev/null; then
+        sudo -n ./setup_systemd.sh "${bot_user}" >>"${LOG_FILE}" 2>&1 && return 0
+    fi
+
+    log "⚠️ Could not reinstall systemd units automatically (need root)."
+    log "   Run once to activate the new update schedule: sudo ./setup_systemd.sh ${bot_user}"
+    return 1
+}
+
+# Self-heal: if the installed update timer no longer matches the one in the
+# repo (e.g. this very change bumped it from daily 5 AM to every 15 min),
+# reinstall the units so the new schedule takes effect — even when there's no
+# new commit to pull. This is what makes the cadence change converge on its own
+# after the (older) updater first pulls it. Reinstalling units does NOT restart
+# the bot, so it's safe to run during a session.
+ensure_systemd_units_current() {
+    under_systemd || return 0
+
+    local repo_timer="deploy/shootybot-update.timer"
+    local installed_timer="/etc/systemd/system/shootybot-update.timer"
+    [ -f "${repo_timer}" ] || return 0
+
+    if [ ! -f "${installed_timer}" ] || ! cmp -s "${repo_timer}" "${installed_timer}"; then
+        log "🧩 Installed update timer differs from repo — reinstalling units"
+        reinstall_systemd_units
+    fi
+}
+
+# Restart the bot, preferring systemd; fall back to signaling the process
+# (systemd's Restart= policy relaunches it) and finally to the screen path.
+restart_bot() {
+    if under_systemd; then
+        log "🔁 Restarting via systemd (${SYSTEMD_SERVICE})..."
+        if [ "$(id -u)" -eq 0 ] && systemctl restart "${SYSTEMD_SERVICE}" 2>>"${LOG_FILE}"; then
+            return 0
+        elif sudo -n systemctl restart "${SYSTEMD_SERVICE}" 2>>"${LOG_FILE}"; then
+            return 0
+        fi
+        # No privileges for systemctl: signal the bot and let systemd relaunch
+        # it (the update runs in its own cgroup, so this doesn't kill us).
+        log "⚠️ No sudo for systemctl; signaling bot, systemd will relaunch it."
+        pkill -f "python.*bot.py" 2>/dev/null
+        return 0
+    fi
+
+    # Legacy (dev / screen) path
+    start_bot
+}
+
 # Function to apply updates and restart bot
 apply_updates() {
-    log "🔄 Applying updates..."
-    
-    # Stop the bot if running
-    if screen -list | grep -q "${SCREEN_NAME}"; then
-        log "🛑 Stopping bot..."
-        screen -S "${SCREEN_NAME}" -X quit
-        sleep 3
+    # Don't interrupt players: if a session is in progress, defer this update.
+    # We intentionally do NOT pull, so the next cycle re-detects the update and
+    # tries again once the session has ended.
+    if bot_has_active_session; then
+        log "⏸️ Session in progress — deferring update (will retry next cycle)"
+        return 0
     fi
-    
+
+    log "🔄 Applying updates..."
+
+    # Remember where we were so we can tell what the pull changed.
+    local pre_pull_hash
+    pre_pull_hash=$(git rev-parse HEAD)
+
     # Pull latest changes
     git pull origin main 2>&1 | tee -a "${LOG_FILE}"
-    
+
     if [ $? -eq 0 ]; then
         log "✅ Updates applied successfully"
-        
+
+        local changed
+        changed=$(git diff --name-only "${pre_pull_hash}" HEAD 2>/dev/null)
+
         # Update dependencies if requirements.txt changed
-        if git diff HEAD~1 HEAD --name-only | grep -q "requirements.txt"; then
+        if echo "${changed}" | grep -q "requirements.txt"; then
             log "📦 Updating dependencies..."
             source venv/bin/activate && pip install -r requirements.txt 2>&1 | tee -a "${LOG_FILE}"
         fi
-        
-        # Restart the bot
-        start_bot
+
+        # Self-deploy: if the systemd unit definitions changed, reinstall them
+        # so the new schedule/service takes effect.
+        if echo "${changed}" | grep -qE '^(deploy/|setup_systemd\.sh)'; then
+            reinstall_systemd_units
+        fi
+
+        # Restart the bot to run the new code
+        restart_bot
     else
         log "❌ Failed to apply updates"
         # Try to restart with current version
-        start_bot
+        restart_bot
     fi
 }
 
@@ -197,6 +314,8 @@ fi
 # If --force-update is passed, force an update check
 if [ "$1" = "--force-update" ]; then
     log "🔧 Force update requested"
+    # Converge the systemd schedule first (no-op once units match the repo).
+    ensure_systemd_units_current
     if check_for_updates; then
         apply_updates
     else

--- a/setup_auto_update.sh
+++ b/setup_auto_update.sh
@@ -1,10 +1,18 @@
 #!/bin/bash
 
-# Setup script for ShootyBot auto-update cron job
-# This creates a cron job that runs every hour to check for updates
+# Setup script for ShootyBot auto-update cron jobs (legacy / non-systemd path).
+# On a systemd host use setup_systemd.sh instead — it installs an equivalent
+# every-15-minutes update timer.
+#
+# This installs cron jobs that:
+#   • health-check the bot every 15 minutes (restart if down)
+#   • check GitHub for updates every 15 minutes (apply + restart if found,
+#     deferring while a session is in progress)
+#   • start the bot on reboot
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 MONITOR_CRON_JOB="*/15 * * * * cd ${SCRIPT_DIR} && ./run_python_script.sh --monitor >> cron.log 2>&1"
+UPDATE_CRON_JOB="*/15 * * * * cd ${SCRIPT_DIR} && ./run_python_script.sh --force-update >> cron.log 2>&1"
 STARTUP_CRON_JOB="@reboot cd ${SCRIPT_DIR} && ./run_python_script.sh --start >> cron.log 2>&1"
 
 echo "🔧 Setting up ShootyBot auto-update cron job..."
@@ -17,8 +25,9 @@ if crontab -l 2>/dev/null | grep -q "run_python_script.sh"; then
 fi
 
 # Add new cron jobs
-echo "➕ Adding cron jobs for monitoring and auto-start..."
+echo "➕ Adding cron jobs for monitoring, updates and auto-start..."
 (crontab -l 2>/dev/null; echo "$MONITOR_CRON_JOB") | crontab -
+(crontab -l 2>/dev/null; echo "$UPDATE_CRON_JOB") | crontab -
 (crontab -l 2>/dev/null; echo "$STARTUP_CRON_JOB") | crontab -
 
 # Verify cron jobs were added
@@ -32,8 +41,8 @@ if crontab -l 2>/dev/null | grep -q "run_python_script.sh"; then
     echo "   • Auto-start on system reboot"
     echo "   • Health check every 15 minutes"
     echo "   • Auto-restart if bot goes down"
-    echo "   • Check for updates daily at 5 AM"
-    echo "   • Restart automatically if updates are found"
+    echo "   • Check for updates every 15 minutes"
+    echo "   • Apply updates + restart automatically (deferred during a session)"
     echo "   • Log all activities to update.log, monitor.log and cron.log"
     echo ""
     echo "🛠️ Manual commands:"

--- a/tests/unit/handlers/test_reaction_handler.py
+++ b/tests/unit/handlers/test_reaction_handler.py
@@ -1,8 +1,39 @@
 import pytest
 from unittest.mock import Mock, AsyncMock, patch, MagicMock
 import discord
-from handlers.reaction_handler import ReactionHandler, add_react_options
+from handlers.reaction_handler import (
+    ReactionHandler,
+    add_react_options,
+    restore_party_state_from_reactions,
+)
 from config import EMOJI, MESSAGES
+
+
+class _AsyncIter:
+    """Minimal async iterator to stand in for discord's reaction.users()."""
+
+    def __init__(self, items):
+        self._items = list(items)
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        if not self._items:
+            raise StopAsyncIteration
+        return self._items.pop(0)
+
+
+def make_raw_payload(*, user_id=111, channel_id=222, message_id=555,
+                     emoji=EMOJI["THUMBS_UP"], member=None):
+    """Build a fake RawReactionActionEvent payload."""
+    payload = Mock()
+    payload.user_id = user_id
+    payload.channel_id = channel_id
+    payload.message_id = message_id
+    payload.emoji = emoji  # str(emoji) yields the emoji string
+    payload.member = member
+    return payload
 
 
 class TestAddReactOptions:
@@ -39,53 +70,117 @@ class TestReactionHandler:
         return ReactionHandler(bot)
     
     @pytest.mark.asyncio
-    async def test_ignore_bot_reactions(self, handler):
-        """Test that bot reactions are ignored"""
-        reaction = Mock()
-        user = Mock(bot=True)
-        
-        # Should return early for bot users
-        result = await handler.on_reaction_add(reaction, user)
-        assert result is None
-        
-        result = await handler.on_reaction_remove(reaction, user)
-        assert result is None
-    
-    @pytest.mark.asyncio
-    async def test_ignore_non_bot_messages(self, handler, mock_discord_reaction):
-        """Test that reactions on non-bot messages are ignored"""
-        reaction = mock_discord_reaction
-        reaction.message.author = Mock(id=123456)  # Not the bot
-        user = Mock(bot=False)
-        
-        # Should return early for non-bot messages
-        result = await handler.on_reaction_add(reaction, user)
-        assert result is None
-        
-        result = await handler.on_reaction_remove(reaction, user)
-        assert result is None
-    
+    async def test_ignore_own_reactions(self, handler):
+        """The bot's own reactions (matched by user id) are ignored."""
+        payload = make_raw_payload(user_id=handler.bot.user.id)
+        assert await handler.on_raw_reaction_add(payload) is None
+        assert await handler.on_raw_reaction_remove(payload) is None
+
     @pytest.mark.asyncio
     @patch('handlers.reaction_handler.context_manager')
-    async def test_ignore_outdated_messages(self, mock_context_manager, handler, mock_discord_reaction):
-        """Test that reactions on outdated messages are ignored"""
-        # Setup
-        mock_context = Mock()
-        mock_context.current_st_message_id = 999
-        mock_context_manager.get_context.return_value = mock_context
-        
-        reaction = mock_discord_reaction
-        reaction.message.id = 123  # Different from current message
-        reaction.message.author = handler.bot.user
-        reaction.message.channel = Mock(id=111222333)
-        
-        user = Mock(bot=False)
-        
-        # Should return after checking message ID
-        with patch('handlers.reaction_handler.logging'):
-            result = await handler.on_reaction_add(reaction, user)
-            assert result is None
-    
+    async def test_ignore_other_bot_reactions(self, mock_context_manager, handler):
+        """Reactions from other bot accounts are ignored."""
+        ctx = Mock()
+        ctx.current_st_message_id = 555
+        mock_context_manager.get_context.return_value = ctx
+
+        channel = AsyncMock()
+        channel.fetch_message = AsyncMock(return_value=AsyncMock())
+        handler.bot.get_channel = Mock(return_value=channel)
+
+        payload = make_raw_payload(member=Mock(id=111, name="OtherBot", bot=True))
+        assert await handler.on_raw_reaction_add(payload) is None
+
+    @pytest.mark.asyncio
+    @patch('handlers.reaction_handler.context_manager')
+    async def test_ignore_when_no_session_message(self, mock_context_manager, handler):
+        """No current session message -> nothing to update."""
+        ctx = Mock()
+        ctx.current_st_message_id = None
+        mock_context_manager.get_context.return_value = ctx
+        handler.bot.get_channel = Mock()
+
+        payload = make_raw_payload(member=Mock(id=111, name="U", bot=False))
+        assert await handler.on_raw_reaction_add(payload) is None
+        handler.bot.get_channel.assert_not_called()
+
+    @pytest.mark.asyncio
+    @patch('handlers.reaction_handler.context_manager')
+    async def test_ignore_outdated_messages(self, mock_context_manager, handler):
+        """Reactions on a message other than the latest one are ignored."""
+        ctx = Mock()
+        ctx.current_st_message_id = 999  # different from payload.message_id
+        mock_context_manager.get_context.return_value = ctx
+        handler.bot.get_channel = Mock()
+
+        payload = make_raw_payload(message_id=123,
+                                   member=Mock(id=111, name="U", bot=False))
+        assert await handler.on_raw_reaction_add(payload) is None
+        handler.bot.get_channel.assert_not_called()
+
+    @pytest.mark.asyncio
+    @patch('handlers.reaction_handler.party_status_message', return_value="updated")
+    @patch('handlers.reaction_handler.context_manager')
+    async def test_raw_add_thumbs_up_adds_soloq(
+        self, mock_context_manager, mock_status, handler
+    ):
+        """👍 on the session message adds the user to solo queue and re-renders."""
+        ctx = Mock()
+        ctx.current_st_message_id = 555
+        ctx.current_session_id = None  # short-circuit participation tracking
+        ctx.is_soloq_user.return_value = False
+        mock_context_manager.get_context.return_value = ctx
+
+        message = Mock()
+        message.edit = AsyncMock()
+        channel = Mock()
+        channel.fetch_message = AsyncMock(return_value=message)
+        handler.bot.get_channel = Mock(return_value=channel)
+        handler.bot.update_status_with_queue_count = AsyncMock()
+
+        member = Mock(id=111, name="Player", bot=False)
+        payload = make_raw_payload(emoji=EMOJI["THUMBS_UP"], member=member)
+
+        await handler.on_raw_reaction_add(payload)
+
+        ctx.add_soloq_user.assert_called_once_with(member)
+        message.edit.assert_awaited_once_with(content="updated")
+        handler.bot.update_status_with_queue_count.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    @patch('handlers.reaction_handler.party_status_message', return_value="updated")
+    @patch('handlers.reaction_handler.context_manager')
+    async def test_raw_remove_thumbs_up_removes_soloq(
+        self, mock_context_manager, mock_status, handler
+    ):
+        """Removing 👍 removes the user from solo queue (resolved without member)."""
+        ctx = Mock()
+        ctx.current_st_message_id = 555
+        ctx.is_soloq_user.return_value = True
+        mock_context_manager.get_context.return_value = ctx
+
+        message = Mock()
+        message.edit = AsyncMock()
+        guild = Mock()
+        member = Mock(id=111, name="Player", bot=False)
+        guild.get_member = Mock(return_value=member)
+        channel = Mock()
+        channel.guild = guild
+        channel.fetch_message = AsyncMock(return_value=message)
+        handler.bot.get_channel = Mock(return_value=channel)
+        handler.bot.update_status_with_queue_count = AsyncMock()
+
+        # No member on remove payloads — handler must resolve via guild
+        payload = make_raw_payload(emoji=EMOJI["THUMBS_UP"], member=None)
+
+        await handler.on_raw_reaction_remove(payload)
+
+        guild.get_member.assert_called_once_with(111)
+        ctx.remove_soloq_user.assert_called_once_with(member)
+        ctx.remove_plus_ones.assert_called_once_with(member)
+        message.edit.assert_awaited_once_with(content="updated")
+
+
     @pytest.mark.asyncio
     @patch('handlers.reaction_handler.data_manager')
     async def test_track_session_participation(self, mock_data_manager, handler):
@@ -343,6 +438,83 @@ class TestVoiceStateUpdate:
 
         handler.bot.get_channel.assert_not_called()
         handler.bot.update_status_with_queue_count.assert_not_called()
+
+
+class TestRestorePartyState:
+    """Tests for rebuilding party state from reactions after a restart."""
+
+    def _bot(self):
+        bot = Mock()
+        bot.user = Mock(id=999999999)
+        return bot
+
+    def _reaction(self, emoji, users):
+        reaction = Mock()
+        reaction.emoji = emoji
+        reaction.users = Mock(return_value=_AsyncIter(users))
+        return reaction
+
+    @pytest.mark.asyncio
+    @patch('handlers.reaction_handler.database_manager')
+    async def test_restore_rebuilds_soloq_and_relinks_session(self, mock_db):
+        from context_manager import ShootyContext
+
+        bot = self._bot()
+        mock_db.get_all_channel_settings.return_value = [
+            {"channel_id": 555, "current_st_message_id": 777}
+        ]
+        mock_db.get_open_session_for_channel.return_value = {"session_id": "sess-1"}
+
+        player = Mock(id=111, name="Player", bot=False)
+        bot_user = Mock(id=999999999, name="Bot", bot=True)
+
+        message = Mock()
+        message.author = bot.user
+        message.channel = Mock(guild=None)
+        message.reactions = [self._reaction(EMOJI["THUMBS_UP"], [player, bot_user])]
+
+        channel = Mock()
+        channel.fetch_message = AsyncMock(return_value=message)
+        bot.get_channel = Mock(return_value=channel)
+
+        real_ctx = ShootyContext(555)
+        with patch('handlers.reaction_handler.context_manager') as mock_cm:
+            mock_cm.get_context.return_value = real_ctx
+            restored = await restore_party_state_from_reactions(bot)
+
+        assert restored == 1
+        assert player in real_ctx.bot_soloq_user_set
+        assert bot_user not in real_ctx.bot_soloq_user_set  # bots excluded
+        assert real_ctx.current_st_message_id == 777
+        assert real_ctx.current_session_id == "sess-1"
+
+    @pytest.mark.asyncio
+    @patch('handlers.reaction_handler.database_manager')
+    async def test_restore_skips_channels_without_message(self, mock_db):
+        bot = self._bot()
+        mock_db.get_all_channel_settings.return_value = [
+            {"channel_id": 555, "current_st_message_id": None}
+        ]
+        bot.get_channel = Mock()
+
+        restored = await restore_party_state_from_reactions(bot)
+        assert restored == 0
+        bot.get_channel.assert_not_called()
+
+    @pytest.mark.asyncio
+    @patch('handlers.reaction_handler.database_manager')
+    async def test_restore_skips_deleted_message(self, mock_db):
+        bot = self._bot()
+        mock_db.get_all_channel_settings.return_value = [
+            {"channel_id": 555, "current_st_message_id": 777}
+        ]
+        channel = Mock()
+        channel.fetch_message = AsyncMock(side_effect=discord.NotFound(Mock(), "gone"))
+        bot.get_channel = Mock(return_value=channel)
+
+        with patch('handlers.reaction_handler.context_manager'):
+            restored = await restore_party_state_from_reactions(bot)
+        assert restored == 0
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_bot.py
+++ b/tests/unit/test_bot.py
@@ -20,6 +20,7 @@ class TestShootyBotInit:
         assert bot.match_tracker is None
         assert bot._cogs_loaded is False
         assert bot.health_check_file == ".bot_health"
+        assert bot.active_session_file == ".active_session"
         assert bot.command_prefix is not None
 
     def test_init_sets_all_intents(self):
@@ -33,19 +34,21 @@ class TestHealthCheckTask:
     """Test health check functionality"""
 
     @pytest.mark.asyncio
-    async def test_health_check_creates_file(self):
-        """Test that health check creates/updates the health file"""
+    async def test_health_check_creates_files(self):
+        """Test that health check writes the health and active-session files"""
         bot = ShootyBot()
 
         # Mock the file operations
         with patch('builtins.open', create=True) as mock_open:
             mock_file = MagicMock()
             mock_open.return_value.__enter__.return_value = mock_file
+            with patch.object(bot, 'count_active_sessions', return_value=0):
+                await bot.health_check_task()
 
-            await bot.health_check_task()
-
-            mock_open.assert_called_once_with(".bot_health", "w")
-            # Should write a timestamp
+            opened = [c.args[0] for c in mock_open.call_args_list]
+            assert ".bot_health" in opened
+            assert ".active_session" in opened
+            # Should write a timestamp / active marker
             assert mock_file.write.called
 
     @pytest.mark.asyncio
@@ -58,6 +61,33 @@ class TestHealthCheckTask:
                 # Should not raise exception
                 await bot.health_check_task()
                 mock_log.assert_called()
+
+
+class TestCountActiveSessions:
+    """Test the active-session counter used to defer auto-updates"""
+
+    def _ctx(self, session_id=None, soloq=None, fullstack=None):
+        c = Mock()
+        c.current_session_id = session_id
+        c.bot_soloq_user_set = soloq if soloq is not None else set()
+        c.bot_fullstack_user_set = fullstack if fullstack is not None else set()
+        return c
+
+    def test_counts_sessions_and_members(self):
+        bot = ShootyBot()
+        with patch('bot.context_manager') as mock_cm:
+            mock_cm.contexts.values.return_value = [
+                self._ctx(),                       # idle -> not counted
+                self._ctx(session_id="s1"),        # active session id
+                self._ctx(soloq={Mock()}),         # has queued members
+            ]
+            assert bot.count_active_sessions() == 2
+
+    def test_zero_when_all_idle(self):
+        bot = ShootyBot()
+        with patch('bot.context_manager') as mock_cm:
+            mock_cm.contexts.values.return_value = [self._ctx(), self._ctx()]
+            assert bot.count_active_sessions() == 0
 
 
 class TestStorageMonitoring:

--- a/tests/unit/test_session_persistence.py
+++ b/tests/unit/test_session_persistence.py
@@ -1,0 +1,67 @@
+"""Tests for the database methods that back session restoration on restart."""
+import os
+from database import DatabaseManager
+
+
+def create_manager(tmp_path):
+    db_path = os.path.join(tmp_path, "test.db")
+    return DatabaseManager(db_path=db_path)
+
+
+def test_get_open_session_returns_unended(tmp_path):
+    """Only the still-open (end_time IS NULL) session is returned."""
+    mgr = create_manager(tmp_path)
+    channel_id = 555
+
+    mgr.create_session("old", channel_id, started_by=1)
+    mgr.end_session("old", was_full=False)
+    mgr.create_session("current", channel_id, started_by=1)
+
+    open_session = mgr.get_open_session_for_channel(channel_id)
+    assert open_session is not None
+    assert open_session["session_id"] == "current"
+
+
+def test_get_open_session_none_when_all_ended(tmp_path):
+    mgr = create_manager(tmp_path)
+    mgr.create_session("done", 777, started_by=1)
+    mgr.end_session("done", was_full=False)
+
+    assert mgr.get_open_session_for_channel(777) is None
+
+
+def test_get_open_session_none_for_unknown_channel(tmp_path):
+    mgr = create_manager(tmp_path)
+    assert mgr.get_open_session_for_channel(999) is None
+
+
+def test_get_open_session_picks_most_recent(tmp_path):
+    """When two sessions are somehow open, the most recently started wins."""
+    mgr = create_manager(tmp_path)
+    channel_id = 123
+    # start_time is ISO8601 so lexical ordering matches chronological ordering
+    mgr.create_session("first", channel_id, started_by=1)
+    import time
+    time.sleep(0.01)
+    mgr.create_session("second", channel_id, started_by=1)
+
+    open_session = mgr.get_open_session_for_channel(channel_id)
+    assert open_session["session_id"] == "second"
+
+
+def test_get_all_channel_settings(tmp_path):
+    mgr = create_manager(tmp_path)
+    mgr.save_channel_settings(111, role_code="<@&1>", current_st_message_id=1001)
+    mgr.save_channel_settings(222, role_code="<@&2>", current_st_message_id=2002)
+
+    all_settings = mgr.get_all_channel_settings()
+    by_channel = {row["channel_id"]: row for row in all_settings}
+
+    assert set(by_channel) == {111, 222}
+    assert by_channel[111]["current_st_message_id"] == 1001
+    assert by_channel[222]["current_st_message_id"] == 2002
+
+
+def test_get_all_channel_settings_empty(tmp_path):
+    mgr = create_manager(tmp_path)
+    assert mgr.get_all_channel_settings() == []


### PR DESCRIPTION
## Summary

Auto-updates previously ran **once daily at 5 AM**, and a bot restart **lost the active session** — party membership was never persisted, and reactions silently stopped updating the party because the cache-backed reaction events don't fire after a restart. This makes updates fast, non-disruptive, and the session resilient to restarts.

## Auto-update (systemd + legacy cron)
- `deploy/shootybot-update.timer` now fires **every 15 minutes** (`OnCalendar=*:0/15`); `setup_auto_update.sh` installs an equivalent `*/15` update cron.
- `apply_updates()` **defers while a session is in progress** (reads the `.active_session` marker the bot writes) — it never pulls/restarts mid-session, retrying next cycle.
- Restart is **systemd-aware**: `sudo -n systemctl restart` → signal the process (systemd `Restart=` relaunches) → legacy screen fallback.
- **Self-deploying**: systemd unit changes are reinstalled after a pull, and `ensure_systemd_units_current()` self-heals timer drift so a cadence change converges on its own.

## Crash-safe sessions
- `restore_party_state_from_reactions()` (called from `on_ready`) rebuilds soloq/fullstack/ready sets from the session message's reactions and re-links the still-open session via `database.get_open_session_for_channel()` (so `/stend` + recap still work).
- Reaction handling moved to **raw events** (`on_raw_reaction_add/remove`) so it works when the message isn't in the cache (post-restart).
- Bot writes `.active_session` (count + timestamp) from the health task.

## ⚠️ One-time activation
The currently-running (old) updater will pull this but only self-heals the timer on its *next* run. To activate the 15-min cadence instantly, run once after merge/deploy:

```
sudo ./setup_systemd.sh
```

After that, all future changes deploy within 15 min without interrupting sessions. (The auto `sudo -n systemctl restart` needs the bot user to have passwordless sudo; otherwise it falls back to signaling the process — no sudo needed — and logs the manual command. No sudoers entry is auto-installed.)

## Tests
- New `tests/unit/test_session_persistence.py`; raw-event + restore tests in `test_reaction_handler.py`; `count_active_sessions` tests in `test_bot.py`.
- Touched non-discord tests pass locally (54 passed). Shell guard + drift logic exercised directly; both scripts pass `bash -n`.
- Note: `test_bot.py`/cog tests couldn't run on this machine (local discord.py 2.3.2 vs the pinned 2.7.1 — pre-existing env gap); verified `bot.py` additions via a shim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)