### PR TITLE
Don't let stale restored sessions wedge the update guard

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -41,18 +41,17 @@ class ShootyBot(commands.Bot):
         self.active_session_file = ".active_session"
 
     def count_active_sessions(self) -> int:
-        """Count channels with a session currently in progress.
+        """Count channels with players currently queued.
 
-        A session is "in progress" when it has a tracked session id or any
-        queued members. Used to decide whether an auto-update may restart now.
+        Used to decide whether an auto-update may restart now. We count a
+        channel only when it has queued members — a lingering ``current_session_id``
+        with nobody in the party (e.g. a session that was never explicitly
+        ended) is NOT something worth deferring an update for, and counting it
+        would wedge the update guard indefinitely.
         """
         active = 0
         for context in context_manager.contexts.values():
-            has_session = bool(getattr(context, "current_session_id", None))
-            has_members = bool(
-                context.bot_soloq_user_set or context.bot_fullstack_user_set
-            )
-            if has_session or has_members:
+            if context.bot_soloq_user_set or context.bot_fullstack_user_set:
                 active += 1
         return active
 

--- a/handlers/reaction_handler.py
+++ b/handlers/reaction_handler.py
@@ -1,4 +1,5 @@
 import logging
+from datetime import timedelta
 from typing import Optional, Union
 import discord
 from discord.ext import commands
@@ -11,6 +12,13 @@ from config import EMOJI, MESSAGES
 # Emojis that join the party and therefore define membership when we rebuild
 # state from a message's reactions after a restart.
 _PARTY_EMOJIS = {EMOJI["THUMBS_UP"], EMOJI["FULL_STACK"], EMOJI["READY"]}
+
+# Only rebuild state from a *recent* session message on startup. A channel's
+# saved current_st_message_id can be days/weeks old (the DB keeps many sessions
+# that were never explicitly ended); reviving those would resurrect long-dead
+# parties and — because they'd report as "active" forever — permanently wedge
+# the auto-update session guard. 12h comfortably covers a real gaming night.
+RESTORE_MAX_AGE_HOURS = 12
 
 
 async def add_react_options(message: discord.Message) -> None:
@@ -38,6 +46,16 @@ async def restore_party_state_from_reactions(bot: commands.Bot) -> int:
         message_id = settings.get("current_st_message_id")
         channel_id = settings.get("channel_id")
         if not message_id or not channel_id:
+            continue
+
+        # Skip stale sessions (snowflake carries the message's creation time),
+        # so we don't revive long-dead parties or wedge the update guard.
+        age = discord.utils.utcnow() - discord.utils.snowflake_time(message_id)
+        if age > timedelta(hours=RESTORE_MAX_AGE_HOURS):
+            logging.info(
+                f"Restore: session message in channel {channel_id} is too old "
+                f"({age}) — skipping"
+            )
             continue
 
         channel = bot.get_channel(channel_id)

--- a/tests/unit/handlers/test_reaction_handler.py
+++ b/tests/unit/handlers/test_reaction_handler.py
@@ -454,14 +454,19 @@ class TestRestorePartyState:
         reaction.users = Mock(return_value=_AsyncIter(users))
         return reaction
 
+    def _recent_msg_id(self):
+        """A snowflake whose embedded timestamp is 'now' (passes recency gate)."""
+        return discord.utils.time_snowflake(discord.utils.utcnow())
+
     @pytest.mark.asyncio
     @patch('handlers.reaction_handler.database_manager')
     async def test_restore_rebuilds_soloq_and_relinks_session(self, mock_db):
         from context_manager import ShootyContext
 
         bot = self._bot()
+        msg_id = self._recent_msg_id()
         mock_db.get_all_channel_settings.return_value = [
-            {"channel_id": 555, "current_st_message_id": 777}
+            {"channel_id": 555, "current_st_message_id": msg_id}
         ]
         mock_db.get_open_session_for_channel.return_value = {"session_id": "sess-1"}
 
@@ -485,8 +490,23 @@ class TestRestorePartyState:
         assert restored == 1
         assert player in real_ctx.bot_soloq_user_set
         assert bot_user not in real_ctx.bot_soloq_user_set  # bots excluded
-        assert real_ctx.current_st_message_id == 777
+        assert real_ctx.current_st_message_id == msg_id
         assert real_ctx.current_session_id == "sess-1"
+
+    @pytest.mark.asyncio
+    @patch('handlers.reaction_handler.database_manager')
+    async def test_restore_skips_stale_message(self, mock_db):
+        """A weeks-old session message must NOT be revived (would wedge updates)."""
+        bot = self._bot()
+        # Snowflake 777 -> ~2015, far older than RESTORE_MAX_AGE_HOURS
+        mock_db.get_all_channel_settings.return_value = [
+            {"channel_id": 555, "current_st_message_id": 777}
+        ]
+        bot.get_channel = Mock()
+
+        restored = await restore_party_state_from_reactions(bot)
+        assert restored == 0
+        bot.get_channel.assert_not_called()  # skipped before any fetch
 
     @pytest.mark.asyncio
     @patch('handlers.reaction_handler.database_manager')
@@ -505,8 +525,9 @@ class TestRestorePartyState:
     @patch('handlers.reaction_handler.database_manager')
     async def test_restore_skips_deleted_message(self, mock_db):
         bot = self._bot()
+        msg_id = self._recent_msg_id()
         mock_db.get_all_channel_settings.return_value = [
-            {"channel_id": 555, "current_st_message_id": 777}
+            {"channel_id": 555, "current_st_message_id": msg_id}
         ]
         channel = Mock()
         channel.fetch_message = AsyncMock(side_effect=discord.NotFound(Mock(), "gone"))

--- a/tests/unit/test_bot.py
+++ b/tests/unit/test_bot.py
@@ -73,13 +73,14 @@ class TestCountActiveSessions:
         c.bot_fullstack_user_set = fullstack if fullstack is not None else set()
         return c
 
-    def test_counts_sessions_and_members(self):
+    def test_counts_only_channels_with_members(self):
         bot = ShootyBot()
         with patch('bot.context_manager') as mock_cm:
             mock_cm.contexts.values.return_value = [
                 self._ctx(),                       # idle -> not counted
-                self._ctx(session_id="s1"),        # active session id
-                self._ctx(soloq={Mock()}),         # has queued members
+                self._ctx(session_id="s1"),        # session id but NO members -> not counted
+                self._ctx(soloq={Mock()}),         # has queued members -> counted
+                self._ctx(fullstack={Mock()}),     # has queued members -> counted
             ]
             assert bot.count_active_sessions() == 2
 


### PR DESCRIPTION
## Context
Follow-up to #71, found while activating it on the Pi. After the bot restarted with the new code, `restore_party_state_from_reactions` rebuilt party state for **5 channels** — but several were *stale* sessions (the DB has 78 sessions that were never `end_time`d). Those channels have no `stack_state` row, so the inactive-stack auto-end (which needs `has_played=True`) never clears them, and `count_active_sessions` counted any channel with a lingering `current_session_id`. Net effect: the `.active_session` marker stays `>0` forever → **auto-updates deferred indefinitely**.

## Fix
- **Restore skips stale messages**: only rebuild from a session message newer than `RESTORE_MAX_AGE_HOURS` (12h), via the message snowflake's timestamp. Long-dead parties aren't resurrected, and an inaccessible channel (`403`) is already skipped gracefully.
- **`count_active_sessions` requires queued members**: a session id with nobody in the party no longer blocks updates.

## Tests
- `count_active_sessions` members-only test; restore stale-skip test added; existing restore tests updated to use a recent snowflake. 29 reaction/persistence tests pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)