### PR TITLE
Refactor scoreboard layout to use aligned inline fields

### DIFF
--- a/match_tracker.py
+++ b/match_tracker.py
@@ -740,19 +740,22 @@ class MatchTracker:
             key=lambda t: (t['kills'] + t['assists']) / max(t['deaths'], 1),
             reverse=True
         )
-        scoreboard = []
+        # Render as three inline fields so Discord lays them out as aligned
+        # columns (Player | K/D/A | KDA) without a code block — inline fields
+        # share one row and line up, avoiding the grey ``ansi`` table background.
+        names, kdas, ratios = [], [], []
         for i, t in enumerate(ranked):
             kda = (t['kills'] + t['assists']) / max(t['deaths'], 1)
             crown = "👑 " if i == 0 and len(ranked) > 1 else ""
-            scoreboard.append(
-                f"{crown}**{t['member'].display_name}** — {t['kills']}/{t['deaths']}/{t['assists']} "
-                f"({kda:.2f} KDA, {t['games']}G)"
-            )
-        embed.add_field(
-            name="🏅 Squad Scoreboard",
-            value="\n".join(scoreboard) or "No player data",
-            inline=False
-        )
+            names.append(f"{crown}**{t['member'].display_name}**")
+            kdas.append(f"{t['kills']}/{t['deaths']}/{t['assists']}")
+            ratios.append(f"{kda:.2f} · {t['games']}G")
+        if names:
+            embed.add_field(name="🏅 Squad Scoreboard", value="\n".join(names), inline=True)
+            embed.add_field(name="K / D / A", value="\n".join(kdas), inline=True)
+            embed.add_field(name="KDA · Games", value="\n".join(ratios), inline=True)
+        else:
+            embed.add_field(name="🏅 Squad Scoreboard", value="No player data", inline=False)
 
         if len(ranked) > 1:
             embed.add_field(


### PR DESCRIPTION
## Summary
Refactored the squad scoreboard in session recaps to display as three aligned inline fields instead of a single multi-line field. This improves readability by presenting player statistics in a clean columnar format without the grey code block background.

## Changes
- **Restructured scoreboard data**: Split the single scoreboard list into three separate lists (`names`, `kdas`, `ratios`) to enable column-based layout
- **Changed field layout**: Replaced one `inline=False` field with three `inline=True` fields:
  - Column 1: Player names (with crown emoji for top player)
  - Column 2: Kill/Death/Assist stats (K/D/A format)
  - Column 3: KDA ratio and game count (formatted as "X.XX · YG")
- **Improved formatting**: Simplified stat display by using separators (·) instead of parentheses for better visual alignment
- **Added empty state handling**: Preserved "No player data" message when no participants exist

## Implementation Details
- Discord's inline field layout automatically aligns multiple `inline=True` fields on a single row, creating a natural columnar appearance
- This avoids the grey ``ansi`` code block background that was present in the previous single-field approach
- The three-column format makes it easier to scan player names, their stats, and KDA ratios at a glance

https://claude.ai/code/session_01YKCHThdz4NTg4dBr11L91S