### PR TITLE
Show agent name per player in post-match recap

### DIFF
--- a/match_stats_display.py
+++ b/match_stats_display.py
@@ -65,6 +65,8 @@ def player_display_stats(match: Dict[str, Any], player_data: Dict[str, Any],
         hs = round(stats.get('headshots', 0) / shots * 100) if shots else 0
         kast = first_kills = first_deaths = multikills = 0
 
+    agent = player_data.get('character', '') or ''
+
     return {
         'kills': kills, 'deaths': deaths, 'assists': assists,
         'acs': round(score / rounds) if rounds else 0,
@@ -73,6 +75,7 @@ def player_display_stats(match: Dict[str, Any], player_data: Dict[str, Any],
         'kda': (kills + assists) / deaths if deaths else float(kills + assists),
         'hs': hs, 'kast': kast,
         'fk': first_kills, 'fd': first_deaths, 'mk': multikills,
+        'agent': agent,
     }
 
 

--- a/match_tracker.py
+++ b/match_tracker.py
@@ -427,9 +427,13 @@ class MatchTracker:
         member_list = []
         for display_name, s, rank_str, rankup_str in entries:
             kda = f"{s['kills']}/{s['deaths']}/{s['assists']}"
+            # Show the agent each player ran, omitting it when unknown so the
+            # line stays clean for untracked/sparse data.
+            agent = s.get('agent', '')
+            agent_str = f" ({agent})" if agent and agent.lower() != 'unknown' else ""
             # ACS/ADR live in the Advanced Stats popup — the per-player recap
             # line stays lean with just K/D/A and rank to cut the noise.
-            member_list.append(f"• **{display_name}**: {kda}{rank_str}{rankup_str}")
+            member_list.append(f"• **{display_name}**{agent_str}: {kda}{rank_str}{rankup_str}")
 
         # One-line squad roll-up above the per-player lines.
         if entries:

--- a/tests/unit/test_match_stats_display.py
+++ b/tests/unit/test_match_stats_display.py
@@ -51,6 +51,19 @@ def test_player_display_stats_falls_back_to_basic_scoreboard():
     assert s['acs'] == 250   # 5000 / 20
     assert s['adr'] == 150   # 3000 / 20
     assert s['kast'] == 0 and s['fk'] == 0
+    # No 'character' in the basic player_data → agent comes back empty.
+    assert s['agent'] == ''
+
+
+def test_player_display_stats_includes_agent():
+    """The agent (Henrik 'character') is surfaced so the recap can show it."""
+    match = {'metadata': {'rounds_played': 20}, 'rounds': [],
+             'players': {'all_players': []}}
+    pdata = {'character': 'Jett',
+             'stats': {'kills': 10, 'deaths': 5, 'assists': 3, 'score': 5000},
+             'damage_made': 3000}
+    s = msd.player_display_stats(match, pdata, puuid=None)
+    assert s['agent'] == 'Jett'
 
 
 # --- advanced scoreboard ----------------------------------------------------


### PR DESCRIPTION
## What

Each squad member's line in the post-match recap now shows the Valorant **agent** they played:

**Before**
```
• Shaaado: 18/9/6 • 🔴 Immortal 2 ⬆️ Rank Up!
• varzz: 14/11/7 • 🟣 Diamond 3
```

**After**
```
• Shaaado (Jett): 18/9/6 • 🔴 Immortal 2 ⬆️ Rank Up!
• varzz (Omen): 14/11/7 • 🟣 Diamond 3
```

## How

- `player_display_stats()` (`match_stats_display.py`) now returns an `agent` field, sourced from the Henrik `character` field already present in the match data — no extra API calls.
- `match_tracker.py` weaves it into the `👥 Squad` line. Unknown/missing agents are omitted (no empty `()`), so untracked teammates and sparse test data render cleanly.

## Tests

- Added two unit tests covering the new `agent` field (present and empty cases).
- Full recap suite green: `test_match_stats_display`, `test_untracked_squad_members`, `test_fun_match_stats`, `test_post_match_comments` (20 passed). The wider suite is 273 passed; the only failures are pre-existing integration tests that need a live Henrik API key (403 in CI sandbox), unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011D5kAtVYiich1EhhFNASz6

---
_Generated by [Claude Code](https://claude.ai/code/session_011D5kAtVYiich1EhhFNASz6)_