### PR TITLE
Fix rank-up detection using per-match mmr-history data.

### DIFF
--- a/match_tracker.py
+++ b/match_tracker.py
@@ -391,7 +391,9 @@ class MatchTracker:
         tracked_puuids = set()
 
         # Members who crossed up a full tier this game (shown inline)
-        ranked_up_ids = await self._get_ranked_up_member_ids(discord_members)
+        ranked_up_ids = await self._get_ranked_up_member_ids(
+            discord_members, match_id=match_id or None
+        )
 
         for dm in discord_members:
             member = dm['member']
@@ -571,12 +573,25 @@ class MatchTracker:
 
         return "🏆 GG", "\n".join(lines)
 
-    async def _get_ranked_up_member_ids(self, discord_members: List[Dict]) -> set:
+    @staticmethod
+    def _is_full_tier_promotion(rr: Optional[int], change: Optional[int]) -> bool:
+        """True when a positive RR gain crossed a sub-rank boundary this game."""
+        if rr is None or change is None or change <= 0:
+            return False
+        return (rr - change) < 0
+
+    async def _get_ranked_up_member_ids(
+        self, discord_members: List[Dict], match_id: Optional[str] = None
+    ) -> set:
         """Return the ids of squad members who crossed up a full tier this game.
 
-        A promotion is detected when the last game's RR gain pushed the player
-        past a tier boundary: their pre-game RR-in-tier
-        (``ranking_in_tier - mmr_change``) was below zero.
+        A promotion is detected when the game's RR gain pushed the player past a
+        tier boundary: their pre-game RR-in-tier (``rr - rr_change``) was below
+        zero.
+
+        Prefer the per-match mmr-history row for ``match_id`` (same source used
+        to detect the game) so we don't miss promotions from a stale cached MMR
+        snapshot. Fall back to a fresh MMR fetch when history is unavailable.
 
         Best-effort: silently skips members whose MMR can't be fetched (private
         profile, API down, no key), so the recap still renders without them.
@@ -589,25 +604,41 @@ class MatchTracker:
             if not username or not tag:
                 continue
 
-            try:
-                mmr = await valorant_client.get_mmr(username, tag, puuid=account.get('puuid'))
-            except Exception as e:
-                log_error(f"fetching rank for {username}#{tag}", e)
-                mmr = None
+            rr = None
+            change = None
+            puuid = account.get('puuid')
 
-            if not mmr:
-                continue
+            if match_id:
+                try:
+                    updates = await valorant_client.get_recent_competitive_updates(
+                        username, tag, puuid=puuid, force_refresh=True
+                    )
+                except Exception as e:
+                    log_error(f"fetching mmr-history for {username}#{tag}", e)
+                    updates = None
 
-            rr = mmr.get('rr')
-            change = mmr.get('rr_change')
-            # Genuine promotion: a positive RR change whose pre-game RR-in-tier
-            # was negative means a tier boundary was crossed this game.
-            if rr is None or change is None or change <= 0:
-                continue
-            if (rr - change) >= 0:
-                continue
+                if updates:
+                    for update in updates:
+                        if update.get('match_id') == match_id:
+                            rr = update.get('rr')
+                            change = update.get('rr_change')
+                            break
 
-            ranked_up.add(dm['member'].id)
+            if rr is None or change is None:
+                try:
+                    mmr = await valorant_client.get_mmr(
+                        username, tag, puuid=puuid, force_refresh=True
+                    )
+                except Exception as e:
+                    log_error(f"fetching rank for {username}#{tag}", e)
+                    mmr = None
+
+                if mmr:
+                    rr = mmr.get('rr')
+                    change = mmr.get('rr_change')
+
+            if self._is_full_tier_promotion(rr, change):
+                ranked_up.add(dm['member'].id)
 
         return ranked_up
 

--- a/tests/unit/test_henrik_efficiency.py
+++ b/tests/unit/test_henrik_efficiency.py
@@ -232,8 +232,10 @@ class TestLightweightEndpoints:
     @pytest.mark.asyncio
     async def test_recent_competitive_updates_normalization(self, client):
         payload = {'data': [
-            {'match_id': 'm-new', 'mmr_change_to_last_game': 18, 'date_raw': 1700009999},
-            {'match_id': 'm-old', 'mmr_change_to_last_game': -12, 'date_raw': 1700000000},
+            {'match_id': 'm-new', 'mmr_change_to_last_game': 18, 'ranking_in_tier': 5,
+             'date_raw': 1700009999},
+            {'match_id': 'm-old', 'mmr_change_to_last_game': -12, 'ranking_in_tier': 40,
+             'date_raw': 1700000000},
         ]}
         client.get = AsyncMock(return_value=APIResponse(data=payload, status_code=200))
 
@@ -243,6 +245,7 @@ class TestLightweightEndpoints:
         assert endpoint == 'v1/by-puuid/mmr-history/na/abc'
         assert result[0]['match_id'] == 'm-new'
         assert result[0]['rr_change'] == 18
+        assert result[0]['rr'] == 5
         assert result[0]['started_at'] is not None
 
     @pytest.mark.asyncio

--- a/tests/unit/test_rank_features.py
+++ b/tests/unit/test_rank_features.py
@@ -169,6 +169,29 @@ async def test_match_embed_shows_inline_rank_up(discord_member_factory):
 # ---------------------------------------------------------------------------
 
 @pytest.mark.asyncio
+async def test_ranked_up_detected_from_mmr_history_for_match(discord_member_factory):
+    """Use the per-match mmr-history row so promotions aren't missed by stale MMR cache."""
+    bot = MagicMock(spec=discord.Client)
+    tracker = MatchTracker(bot)
+    member = discord_member_factory(user_id=1, name='Player1')
+    discord_members = [{'member': member,
+                        'account': {'puuid': 'p1', 'username': 'Player1', 'tag': 'NA1'}}]
+
+    fake_client = MagicMock()
+    fake_client.get_recent_competitive_updates = AsyncMock(return_value=[
+        {'match_id': 'game-123', 'rr': 5, 'rr_change': 18, 'started_at': None},
+    ])
+    fake_client.get_mmr = AsyncMock()
+    with patch('match_tracker.valorant_client', fake_client):
+        result = await tracker._get_ranked_up_member_ids(
+            discord_members, match_id='game-123'
+        )
+
+    assert result == {1}
+    fake_client.get_mmr.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_ranked_up_detected_on_promotion(discord_member_factory):
     bot = MagicMock(spec=discord.Client)
     tracker = MatchTracker(bot)

--- a/valorant_client.py
+++ b/valorant_client.py
@@ -441,6 +441,8 @@ class ValorantClient(BaseAPIClient):
                     'match_id': match_id,
                     'started_at': started,
                     'rr_change': entry.get('mmr_change_to_last_game'),
+                    # Post-game RR for this specific match (used for rank-up detection)
+                    'rr': entry.get('ranking_in_tier'),
                 })
             return normalized
         except Exception as e:


### PR DESCRIPTION
Stale cached MMR snapshots could miss promotions in post-game recaps; prefer the match-specific mmr-history row and force-refresh fallbacks.