### PR TITLE
Add weapon-personality recap highlights for the full arsenal

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -420,6 +420,15 @@ ShootyBot uses a tiered approach to keep Henrik API usage cheap and fast:
   one per category, max 2 per member). To add a highlight, add a candidate with an
   interest score (rare plays like aces/ninja defuses ~90+, fillers ~20-40) — never
   append directly to the highlights list.
+- **Weapon highlights** are table-driven off `MatchTracker.WEAPON_HIGHLIGHTS`
+  (`category, weapon names, min kills, score, template`) — add a row there rather
+  than writing new branching. Weapon names must be **lowercased** Henrik
+  `damage_weapon_name` values (the tally lowercases before lookup); listing several
+  in one row sums them (Odin+Ares share the LMG highlight). Each entry goes to the
+  squad's *leader* for that weapon, so one gun can't fill the recap. Knife/melee is
+  the exception — it's per-member and scored ~90+ alongside the rare plays. Vandal
+  and Phantom are deliberately excluded: everyone gets rifle kills every match, so
+  the "look at that gun choice" joke doesn't land.
 
 ### Configuration:
 - `HENRIK_API_KEY` (required by Henrik), `HENRIK_REQUESTS_PER_MINUTE` (Basic=30, Advanced=90),

--- a/match_tracker.py
+++ b/match_tracker.py
@@ -46,7 +46,7 @@ class MatchTracker:
         ('bucky', ('bucky',), 3, 56,
          "🤠 **BUCKEROO**: {name} bought a Bucky on purpose and got {kills} kills"),
         ('operator', ('operator',), 5, 56,
-         "🎣 **OP CRUTCH**: {name} leaned on the Operator for {kills} kills"),
+         "🩼 **OP CRUTCH**: {name} leaned on the Operator for {kills} kills"),
         ('shorty', ('shorty',), 2, 54,
          "🩳 **TWO PUMP CHUMP**: {name} got {kills} Shorty kills"),
         ('bulldog', ('bulldog',), 4, 54,

--- a/match_tracker.py
+++ b/match_tracker.py
@@ -24,7 +24,50 @@ class MatchTracker:
     HEADSHOT_THRESHOLD_PERCENT = 30
     HIGH_DAMAGE_THRESHOLD = 3000
     STACK_INACTIVITY_HOURS = 1.5  # Auto-end stacks after 1.5 hours of no games
-    
+
+    # Weapon-personality recap highlights, as
+    # (category, weapon names, min kills, interest score, message template).
+    # Weapon names are lowercased Henrik `damage_weapon_name` values; grouping
+    # several under one entry sums them (the LMGs share a highlight). Only the
+    # squad's leader for each weapon gets the callout, so one gun can't fill the
+    # whole recap. Scores stay in the filler-to-mid band - the joke is the gun
+    # choice, so these should never outrank an ace or a ninja defuse.
+    # Vandal/Phantom are deliberately absent: nearly everyone gets rifle kills
+    # every match, so a rifle highlight either never fires or never stops.
+    WEAPON_HIGHLIGHTS = (
+        ('sheriff', ('sheriff',), 3, 60,
+         "🇨🇳 **CHINESE VANDAL**: {name} one-tapped {kills} people with the Sheriff"),
+        ('judge', ('judge',), 4, 58,
+         "⚖️ **JUDGE DEMON**: {name} held W into {kills} Judge kills"),
+        ('lmg', ('odin', 'ares'), 4, 58,
+         "🎯 **PRECISE GUNPLAY**: {name} carefully placed {kills} LMG kills"),
+        ('classic', ('classic',), 3, 56,
+         "🇪🇸 **EL CLASSICO**: {name} got {kills} kills with the free pistol"),
+        ('bucky', ('bucky',), 3, 56,
+         "🤠 **BUCKEROO**: {name} bought a Bucky on purpose and got {kills} kills"),
+        ('operator', ('operator',), 5, 56,
+         "🎣 **OP CRUTCH**: {name} leaned on the Operator for {kills} kills"),
+        ('shorty', ('shorty',), 2, 54,
+         "🩳 **TWO PUMP CHUMP**: {name} got {kills} Shorty kills"),
+        ('bulldog', ('bulldog',), 4, 54,
+         "🍜 **BULDAK ENJOYER**: {name} still believes in the Bulldog ({kills} kills)"),
+        ('stinger', ('stinger',), 4, 52,
+         "🐝 **STINGER GENIUS**: {name} out-thought the lobby for {kills} Stinger kills"),
+        ('frenzy', ('frenzy',), 3, 50,
+         "🎰 **KILLING FRENZY**: {name} sprayed down {kills} with the Frenzy"),
+        ('guardian', ('guardian',), 5, 50,
+         "🟢 **HALO 5**: {name} clicked {kills} heads with the Guardian"),
+        ('outlaw', ('outlaw',), 3, 50,
+         "🐎 **RENEGADE**: {name} got {kills} kills with the Outlaw"),
+        ('marshal', ('marshal',), 3, 48,
+         "🔨 **MARSHAL LAW**: {name} laid down the law {kills} times"),
+        ('ghost', ('ghost',), 4, 44,
+         "👻 **GHOST IN THE SHELL**: {name} got {kills} Ghost kills"),
+        ('spectre', ('spectre',), 6, 42,
+         "🎮 **COD PLAYER**: {name} ran and gunned {kills} Spectre kills"),
+    )
+
+
     def __init__(self, bot: discord.Client) -> None:
         self.bot = bot
         # State is now persisted to database - these are kept as memory caches for performance
@@ -1372,32 +1415,32 @@ class MatchTracker:
                 f"🥄 **BUDGET WARRIOR**: {eco_hero[0].display_name} won {eco_wins} rounds on eco buys",
                 eco_hero[0].id)
 
-        # Weapon personality
+        # Weapon personality. Knife kills stay per-member because they're rare
+        # enough that everyone who lands one has earned the callout; every other
+        # weapon is table-driven off WEAPON_HIGHLIGHTS and awarded to the squad's
+        # leader for that gun.
+        weapon_tallies = []
         for member, row in rows:
             weapon_kills = {str(k).lower(): v for k, v in (row.get('weapon_kills') or {}).items()}
+            weapon_tallies.append((member, weapon_kills))
+
             knife_kills = sum(v for k, v in weapon_kills.items() if 'melee' in k or 'knife' in k)
             if knife_kills:
                 plural = 's' if knife_kills > 1 else ''
                 # Knife kills are rare and always worth showing - score them up
                 # there with aces/ninja defuses, and reward stacking them.
                 add(candidates, min(96, 90 + 2 * knife_kills), f'knife:{member.id}',
-                    f"🔪 **HUMILIATION**: {member.display_name} got {knife_kills} knife kill{plural}!",
+                    f"🗡️ **EZIO AUDITORE**: {member.display_name} got {knife_kills} knife kill{plural}!",
                     member.id)
-            sheriff_kills = weapon_kills.get('sheriff', 0)
-            if sheriff_kills >= 3:
-                add(candidates, 60, 'sheriff',
-                    f"🤠 **SHERIFF SHOWDOWN**: {member.display_name} landed {sheriff_kills} Sheriff kills",
-                    member.id)
-            odin_kills = weapon_kills.get('odin', 0) + weapon_kills.get('ares', 0)
-            if odin_kills >= 4:
-                add(candidates, 58, 'odin',
-                    f"🚜 **MACHINE GUN MAIN**: {member.display_name} mowed down {odin_kills} with the LMG",
-                    member.id)
-            operator_kills = weapon_kills.get('operator', 0)
-            if operator_kills >= 5:
-                add(candidates, 56, 'operator',
-                    f"🔭 **OPERATOR MENACE**: {member.display_name} got {operator_kills} Operator kills",
-                    member.id)
+
+        for category, weapons, min_kills, score, template in self.WEAPON_HIGHLIGHTS:
+            leader, kills = max(
+                ((member, sum(wk.get(w, 0) for w in weapons)) for member, wk in weapon_tallies),
+                key=lambda mk: mk[1])
+            if kills >= min_kills:
+                add(candidates, score, category,
+                    template.format(name=leader.display_name, kills=kills),
+                    leader.id)
 
         # Spike plays
         for member, row in rows:

--- a/tests/unit/test_advanced_match_stats.py
+++ b/tests/unit/test_advanced_match_stats.py
@@ -245,6 +245,117 @@ class TestAggregateExtras:
         assert stats['total_matches'] == 2
 
 
+def build_weapon_match(weapon_kills):
+    """Build a minimal match giving each puuid the requested per-weapon kill
+    counts, one kill per round so nothing accidentally reads as a multikill.
+
+    weapon_kills: {puuid: {weapon_name: kills}}
+    """
+    rounds = []
+    for puuid, weapons in weapon_kills.items():
+        for weapon, count in weapons.items():
+            for _ in range(count):
+                rounds.append({
+                    'winning_team': 'Red',
+                    'plant_events': {},
+                    'defuse_events': {},
+                    'player_stats': [{
+                        'player_puuid': puuid,
+                        'kills': 1,
+                        'economy': {},
+                        'kill_events': [{
+                            'victim_puuid': 'ENEMY',
+                            'kill_time_in_round': 5000,
+                            'damage_weapon_name': weapon,
+                            'assistants': [],
+                        }],
+                    }],
+                })
+    return {
+        'metadata': {'matchid': 'weapon-match', 'map': 'Ascent', 'mode': 'Competitive',
+                     'mode_id': 'competitive', 'rounds_played': len(rounds),
+                     'game_start': 1700000000, 'game_length': 1800},
+        'players': {'all_players': [make_player(p, 'Red') for p in weapon_kills]},
+        'teams': {'red': {'has_won': True, 'rounds_won': len(rounds)},
+                  'blue': {'has_won': False, 'rounds_won': 0}},
+        'rounds': rounds,
+    }
+
+
+def weapon_candidates(discord_member_factory, weapon_kills, names=None):
+    """Run the advanced candidate pass over a weapon-only match and return the
+    candidate texts (not the selected highlights, so the per-member cap and
+    unrelated highlights can't hide what we're asserting on)."""
+    tracker = MatchTracker(MagicMock(spec=discord.Client))
+    match_data = build_weapon_match(weapon_kills)
+    names = names or {}
+    discord_members = []
+    for idx, (puuid, player) in enumerate(
+            zip(weapon_kills, match_data['players']['all_players']), start=1):
+        member = discord_member_factory(user_id=idx, name=names.get(puuid, f'Player{idx}'))
+        discord_members.append({'member': member, 'account': {'puuid': puuid},
+                                'player_data': player})
+
+    candidates = []
+    tracker._add_advanced_candidates(candidates, match_data, discord_members)
+    return [c['text'] for c in candidates]
+
+
+class TestWeaponHighlights:
+    def test_table_is_well_formed(self):
+        categories = [entry[0] for entry in MatchTracker.WEAPON_HIGHLIGHTS]
+        assert len(categories) == len(set(categories)), "duplicate weapon category"
+        for category, weapons, min_kills, score, template in MatchTracker.WEAPON_HIGHLIGHTS:
+            assert weapons and all(w == w.lower() for w in weapons), \
+                f"{category}: weapon names must be lowercased for the tally lookup"
+            assert min_kills >= 1
+            # Weapon jokes must never outrank the rare plays (ace/ninja/knife)
+            assert 20 <= score <= 70, f"{category}: score {score} is out of band"
+            rendered = template.format(name='Someone', kills=min_kills)
+            assert 'Someone' in rendered and str(min_kills) in rendered
+
+    def test_stinger_kills_produce_a_highlight(self, discord_member_factory):
+        texts = weapon_candidates(discord_member_factory, {'A1': {'Stinger': 4}},
+                                  names={'A1': 'Alpha'})
+        assert any('STINGER GENIUS' in t and 'Alpha' in t and '4' in t for t in texts)
+
+    def test_stinger_below_threshold_is_silent(self, discord_member_factory):
+        texts = weapon_candidates(discord_member_factory, {'A1': {'Stinger': 3}})
+        assert not any('STINGER GENIUS' in t for t in texts)
+
+    def test_only_the_squad_leader_gets_the_callout(self, discord_member_factory):
+        texts = weapon_candidates(
+            discord_member_factory,
+            {'A1': {'Stinger': 4}, 'A2': {'Stinger': 6}},
+            names={'A1': 'Alpha', 'A2': 'Bravo'})
+        stinger = [t for t in texts if 'STINGER GENIUS' in t]
+        assert len(stinger) == 1
+        assert 'Bravo' in stinger[0] and '6' in stinger[0]
+
+    def test_lmg_entry_sums_odin_and_ares(self, discord_member_factory):
+        texts = weapon_candidates(discord_member_factory, {'A1': {'Odin': 2, 'Ares': 2}})
+        assert any('PRECISE GUNPLAY' in t and '4' in t for t in texts)
+
+    def test_weapon_names_are_matched_case_insensitively(self, discord_member_factory):
+        # Henrik has shipped inconsistent casing before; the tally lowercases
+        texts = weapon_candidates(discord_member_factory, {'A1': {'sTiNgEr': 4}})
+        assert any('STINGER GENIUS' in t for t in texts)
+
+    def test_rifles_do_not_produce_weapon_highlights(self, discord_member_factory):
+        texts = weapon_candidates(discord_member_factory,
+                                  {'A1': {'Vandal': 15, 'Phantom': 10}})
+        titles = [entry[4].split('**')[1] for entry in MatchTracker.WEAPON_HIGHLIGHTS]
+        assert not any(title in t for t in texts for title in titles)
+
+    def test_every_weapon_in_the_table_can_fire(self, discord_member_factory):
+        """Guards against a typo in a weapon name silently disabling an entry."""
+        for category, weapons, min_kills, score, template in MatchTracker.WEAPON_HIGHLIGHTS:
+            title = template.split('**')[1]
+            texts = weapon_candidates(discord_member_factory,
+                                      {'A1': {weapons[0]: min_kills}})
+            assert any(title in t for t in texts), f"{category} never fires"
+
+
 class TestHighlightSelection:
     def test_picks_highest_scores_with_category_dedupe(self):
         candidates = []
@@ -294,7 +405,7 @@ async def test_advanced_highlights_in_recap(discord_member_factory):
     assert 'Alpha' in joined
     # Ninja defuse (94) and knife kill (92) outrank everything else here
     assert 'NINJA DEFUSE' in highlights[0]
-    assert 'HUMILIATION' in highlights[1]
+    assert 'EZIO AUDITORE' in highlights[1]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Why

Stinger kills weren't showing up in post-game recaps. They were already being **tracked** — `_collect_weapon_kills()` tallies every weapon from kill events into the `weapon_kills` JSON column, and `/shootyweaponstats Stinger` has always worked — but the recap only had highlight candidates for knife, Sheriff, Odin/Ares and Operator. A missing candidate is invisible to `_select_highlights()` rather than merely low-priority, so no amount of Stinger kills could ever surface.

## What changed

Replaced the hardcoded per-weapon `if` chain in `_calculate_fun_match_stats()` with a `MatchTracker.WEAPON_HIGHLIGHTS` table covering 15 entries, and renamed the existing ones.

| Score | Weapon | Thr. | Highlight |
|---|---|---|---|
| — | Melee | ≥1 | 🗡️ **EZIO AUDITORE** *(per-member, 90–96)* |
| 60 | Sheriff | ≥3 | 🇨🇳 **CHINESE VANDAL** |
| 58 | Judge | ≥4 | ⚖️ **JUDGE DEMON** |
| 58 | Odin+Ares | ≥4 | 🎯 **PRECISE GUNPLAY** |
| 56 | Classic | ≥3 | 🇪🇸 **EL CLASSICO** |
| 56 | Bucky | ≥3 | 🤠 **BUCKEROO** |
| 56 | Operator | ≥5 | 🩼 **OP CRUTCH** |
| 54 | Shorty | ≥2 | 🩳 **TWO PUMP CHUMP** |
| 54 | Bulldog | ≥4 | 🍜 **BULDAK ENJOYER** |
| 52 | Stinger | ≥4 | 🐝 **STINGER GENIUS** |
| 50 | Frenzy | ≥3 | 🎰 **KILLING FRENZY** |
| 50 | Guardian | ≥5 | 🟢 **HALO 5** |
| 50 | Outlaw | ≥3 | 🐎 **RENEGADE** |
| 48 | Marshal | ≥3 | 🔨 **MARSHAL LAW** |
| 44 | Ghost | ≥4 | 👻 **GHOST IN THE SHELL** |
| 42 | Spectre | ≥6 | 🎮 **COD PLAYER** |

Three design calls:

- **Leader-only, not per-member.** The old code looped members and added a candidate each, so in a 5-stack the category dedupe picked an effectively arbitrary winner on score ties. Each entry now goes to whoever actually led the squad in that gun. Knife is the deliberate exception — still per-member at 90–96, since it belongs with aces and ninja defuses.
- **Scores capped at 60.** `_select_highlights()` allows max 2 highlights per member, so scoring a Bucky joke at 90 would push someone's real ace out of the recap.
- **Vandal and Phantom excluded.** Nearly everyone gets rifle kills every match, so any threshold either fires constantly or never — and the joke in all of these is the gun choice being odd, which rifles aren't.

## Tests

8 new tests in `TestWeaponHighlights`; 283 pass overall. The notable one is `test_every_weapon_in_the_table_can_fire`, which drives each of the 15 entries to its threshold and asserts the title appears — a typo'd weapon name can't silently disable an entry the way the Stinger gap went unnoticed. Also covers Henrik casing drift (`sTiNgEr`), leader-only selection, LMG summing, and rifles staying excluded.

The 5 errors in `tests/integration/test_match_stats.py` are pre-existing and unrelated — they call the live Henrik API and fail identically on `main`.

## Notes

- Applies to matches recapped from now on. Historical `player_match_stats` rows already hold the weapon data and could be recomputed without API calls, but nothing re-renders old recaps today, so that's left alone.
- 🩼 is U+1FA7C (Emoji 15.0, 2022) — newer than the rest of the set. Discord's Twemoji has it, but a very old phone OS may show tofu; 🦯 is the closest widely-supported substitute if that comes up.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GYJcaxmSNDsX2j2S2KJXWm)_