### PR TITLE
Cut match-detection latency, idle Pi I/O, and make session end/recap automatic

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -410,6 +410,13 @@ ShootyBot uses a tiered approach to keep Henrik API usage cheap and fast:
   queued members (never `get_context()` per text channel), and persists its state only
   when it changed (`_state_dirty`) — an idle cycle does zero SQLite writes, with the
   30-day state cleanup running at most daily.
+- **Sessions end themselves — never rely on `/stend`** (it's almost never used in
+  practice). Once a stack has played and presence has shown members in-game, the
+  tracker auto-ends the session ~20 min after everyone closes Valorant
+  (`STACK_OFFLINE_END_MINUTES`); the 1.5h no-games timer is the fallback for
+  hidden/broken presence (the presence path only arms after presence has actually been
+  seen working for that stack). Both paths post the full session recap to the stack's
+  channel — auto-end does everything `/stend` does, just without the command.
 - **4xx responses are returned, not retried** - only 429 (after waiting) and 5xx/network
   errors go through retry with backoff. Henrik's `x-ratelimit-remaining`/`x-ratelimit-reset`
   headers are honored before sending requests.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -400,9 +400,16 @@ ShootyBot uses a tiered approach to keep Henrik API usage cheap and fast:
   (one bulk matchlist call if >=3 missing, else per-match), and aggregates rows.
   `calculate_player_stats()` is the pure in-memory equivalent (no API/DB) used by legacy
   paths and tests.
-- **Match tracker polling**: polls `get_recent_competitive_updates()` (few KB) per minute;
-  full match details are fetched at most once per new match id, then stat rows are recorded
-  for every linked player in the match (`record_match_stats_for_players`).
+- **Match tracker polling**: polls `get_recent_competitive_updates()` (few KB) for all
+  stack members **concurrently** with `force_refresh=True` (the poll is the freshness
+  source; the 60s response cache would only delay detection). The interval is adaptive:
+  60s baseline, 30s while any queued member's Discord presence shows Valorant open
+  (presence is gateway data — free). Full match details are fetched at most once per new
+  match id, then stat rows are recorded for every linked player in the match
+  (`record_match_stats_for_players`). The tracker iterates only in-memory contexts with
+  queued members (never `get_context()` per text channel), and persists its state only
+  when it changed (`_state_dirty`) — an idle cycle does zero SQLite writes, with the
+  30-day state cleanup running at most daily.
 - **4xx responses are returned, not retried** - only 429 (after waiting) and 5xx/network
   errors go through retry with backoff. Henrik's `x-ratelimit-remaining`/`x-ratelimit-reset`
   headers are honored before sending requests.

--- a/match_tracker.py
+++ b/match_tracker.py
@@ -29,7 +29,13 @@ class MatchTracker:
     LEG_SHOT_THRESHOLD_PERCENT = 15
     HEADSHOT_THRESHOLD_PERCENT = 30
     HIGH_DAMAGE_THRESHOLD = 3000
-    STACK_INACTIVITY_HOURS = 1.5  # Auto-end stacks after 1.5 hours of no games
+    STACK_INACTIVITY_HOURS = 1.5  # Fallback: auto-end stacks after 1.5 hours of no games
+    # Preferred auto-end: once a stack has played and presence has shown members
+    # in-game, end the session this many minutes after everyone closed Valorant.
+    # Much faster than the 1.5h timer, and self-validating: it only arms after
+    # presence has actually been seen working for this stack, so broken/hidden
+    # presence can never end a session early — it just falls back to the timer.
+    STACK_OFFLINE_END_MINUTES = 20
 
     # Weapon-personality recap highlights, as
     # (category, weapon names, min kills, interest score, message template).
@@ -81,6 +87,10 @@ class MatchTracker:
         self.recent_matches: Dict[int, Dict[str, Dict[str, Any]]] = {}   # {server_id: {match_id: {'timestamp': datetime, 'members': []}}}
         self.stack_last_activity: Dict[int, datetime] = {}  # {channel_id: last_match_timestamp}
         self.stack_has_played: Dict[int, bool] = {}  # {channel_id: has_had_games}
+        # Presence heuristics for ending sessions without /stend (memory-only;
+        # a restart just falls back to the inactivity timer, which is safe)
+        self.stack_seen_playing: Dict[int, bool] = {}  # {channel_id: presence ever showed a member in-game}
+        self.stack_offline_since: Dict[int, datetime] = {}  # {channel_id: when everyone stopped playing}
         self.check_interval: int = self.CHECK_INTERVAL_SECONDS
         self.running: bool = False
         self._state_loaded: bool = False
@@ -1715,13 +1725,22 @@ class MatchTracker:
                 logging.info(f"Updated activity for stack in channel {channel.id} - {len(stack_members_in_match)} members played")
     
     async def _check_inactive_stacks(self) -> None:
-        """Check for stacks that have been inactive and auto-end them.
+        """Auto-end stacks whose session is over, without waiting for /stend.
+
+        Two triggers, both of which post the session recap:
+
+        1. Presence-based (fast path): once the stack has played at least one
+           game and presence has shown members in-game, the session ends
+           STACK_OFFLINE_END_MINUTES after every member closed Valorant.
+        2. Inactivity timer (fallback): no detected games for
+           STACK_INACTIVITY_HOURS — covers members with hidden/broken presence.
 
         Walks only the contexts already in memory instead of every text channel
         in every guild — a channel with a live stack always has a context.
         """
         current_time = datetime.now(timezone.utc)
         inactivity_cutoff = timedelta(hours=self.STACK_INACTIVITY_HOURS)
+        offline_cutoff = timedelta(minutes=self.STACK_OFFLINE_END_MINUTES)
 
         for channel_id, context in list(context_manager.contexts.items()):
             try:
@@ -1734,25 +1753,63 @@ class MatchTracker:
                         self._state_dirty = True
                     if self.stack_has_played.pop(channel_id, None) is not None:
                         self._state_dirty = True
+                    self.stack_seen_playing.pop(channel_id, None)
+                    self.stack_offline_since.pop(channel_id, None)
                     continue
 
                 # Only check stacks that have had gaming activity
                 if not self.stack_has_played.get(channel_id, False):
                     continue
 
-                # Check if stack has been inactive
+                # Presence-based fast path: track when everyone stopped playing
+                anyone_playing = any(
+                    valorant_client.is_playing_valorant(user)
+                    for user in all_stack_users
+                    if not getattr(user, 'bot', False)
+                )
+                if anyone_playing:
+                    self.stack_seen_playing[channel_id] = True
+                    self.stack_offline_since.pop(channel_id, None)
+                elif self.stack_seen_playing.get(channel_id, False):
+                    offline_since = self.stack_offline_since.setdefault(channel_id, current_time)
+                    if (current_time - offline_since) >= offline_cutoff:
+                        channel = self.bot.get_channel(channel_id)
+                        if channel is not None:
+                            await self._auto_end_inactive_stack(
+                                channel, context, current_time - offline_since,
+                                reason="everyone offline")
+                            continue
+
+                # Fallback: no detected games for a long time
                 last_activity = self.stack_last_activity.get(channel_id)
                 if last_activity and (current_time - last_activity) > inactivity_cutoff:
                     channel = self.bot.get_channel(channel_id)
                     if channel is not None:
-                        await self._auto_end_inactive_stack(channel, context, current_time - last_activity)
+                        await self._auto_end_inactive_stack(
+                            channel, context, current_time - last_activity,
+                            reason="inactivity")
 
             except Exception as e:
                 log_error(f"checking inactive stack for channel {channel_id}", e)
     
-    async def _auto_end_inactive_stack(self, channel: discord.TextChannel, context, inactivity_duration: timedelta) -> None:
-        """Automatically end an inactive stack"""
+    async def _auto_end_inactive_stack(self, channel: discord.TextChannel, context,
+                                       inactivity_duration: timedelta,
+                                       reason: str = "inactivity") -> None:
+        """Automatically end an inactive stack and post the session recap.
+
+        /stend is rarely used in practice, so this is the path that actually
+        closes sessions — it must do everything /stend does, including the
+        recap, not just silently clear the stack.
+        """
         try:
+            # Capture before ending — _end_current_session resets the stack
+            session_id = getattr(context, 'current_session_id', None)
+            participants = [
+                user for user in
+                context.bot_soloq_user_set.union(context.bot_fullstack_user_set)
+                if not getattr(user, 'bot', False)
+            ]
+
             # Get the session commands cog to end the session properly
             session_cog = self.bot.get_cog('SessionCommands')
             if session_cog:
@@ -1791,16 +1848,44 @@ class MatchTracker:
                 del self.stack_last_activity[channel.id]
             if channel.id in self.stack_has_played:
                 del self.stack_has_played[channel.id]
+            self.stack_seen_playing.pop(channel.id, None)
+            self.stack_offline_since.pop(channel.id, None)
             self._state_dirty = True
 
-
-            # Silently end the stack and log the action
             logging.info(
-                f"Auto-ended inactive stack in channel {channel.id} after {inactivity_duration}"
+                f"Auto-ended stack in channel {channel.id} ({reason}) after {inactivity_duration}"
             )
-            
+
+            # Post the recap so it never depends on someone running /stend
+            await self._send_auto_end_recap(channel, session_id, participants)
+
         except Exception as e:
             log_error(f"auto-ending stack in channel {channel.id}", e)
+
+    async def _send_auto_end_recap(self, channel: discord.TextChannel,
+                                   session_id: Optional[str],
+                                   participants: List[discord.Member]) -> None:
+        """Build and post the session recap for an auto-ended stack (best-effort)."""
+        if not participants:
+            return
+        try:
+            from data_manager import data_manager, SessionData
+            session = None
+            if session_id:
+                session = data_manager.sessions.get(session_id)
+                if session is None:
+                    session = SessionData(session_id)
+            if session is None:
+                return
+
+            embed = await self.build_session_recap(channel.guild, participants, session)
+            if embed:
+                await channel.send(
+                    content="🌙 Squad's logged off — wrapping up the session!",
+                    embed=embed
+                )
+        except Exception as e:
+            log_error(f"sending auto-end recap for channel {channel.id}", e)
     
     async def manual_check_recent_match(self, guild: discord.Guild, member: discord.Member = None, force_fresh: bool = False) -> Optional[discord.Embed]:
         """Manually check for a recent match and return embed if found"""

--- a/match_tracker.py
+++ b/match_tracker.py
@@ -18,6 +18,12 @@ class MatchTracker:
     
     # Configuration constants
     CHECK_INTERVAL_SECONDS = 60  # 1 minute
+    # Faster cadence while someone in a stack has Valorant open (Discord
+    # presence, free to check) — this is when a match can actually finish, so
+    # it's the only time the extra polling spend buys lower detection latency.
+    FAST_CHECK_INTERVAL_SECONDS = 30
+    # Tracker state barely changes; scrub old rows daily, not every poll cycle
+    STATE_CLEANUP_INTERVAL_HOURS = 24
     MATCH_CUTOFF_HOURS = 2
     MIN_DISCORD_MEMBERS = 2
     LEG_SHOT_THRESHOLD_PERCENT = 15
@@ -78,6 +84,13 @@ class MatchTracker:
         self.check_interval: int = self.CHECK_INTERVAL_SECONDS
         self.running: bool = False
         self._state_loaded: bool = False
+        # Set each poll cycle: True when any tracked stack member currently has
+        # Valorant open, which switches the loop to the fast interval.
+        self._any_tracked_playing: bool = False
+        # Persist state only when it actually changed (last_match_id / stack
+        # activity), so an idle bot does zero SD-card writes per cycle.
+        self._state_dirty: bool = False
+        self._last_state_cleanup: Optional[datetime] = None
         
     async def start_tracking(self) -> None:
         """Start the background match tracking task"""
@@ -90,60 +103,91 @@ class MatchTracker:
             self._state_loaded = True
         
         self.running = True
-        logging.info("Starting match tracker with 1-minute polling for active shooty stacks...")
-        
+        logging.info(
+            "Starting match tracker: polling active shooty stacks every "
+            f"{self.check_interval}s ({self.FAST_CHECK_INTERVAL_SECONDS}s while members are in-game)..."
+        )
+
         while self.running:
             try:
                 await self._check_all_servers()
                 await self._check_inactive_stacks()
-                # Periodically save state to database
+                # Persist state when it changed this cycle (no-op otherwise)
                 await self._save_state_to_database()
-                await asyncio.sleep(self.check_interval)
+                await asyncio.sleep(self._current_check_interval())
             except Exception as e:
                 log_error("in match tracker", e)
                 await asyncio.sleep(60)  # Wait 1 minute before retrying
+
+    def _current_check_interval(self) -> int:
+        """Poll faster while a tracked stack member has Valorant open.
+
+        Presence comes from the Discord gateway, so checking it is free — the
+        extra API polling only happens in the window where a match can actually
+        finish, and detection latency is roughly halved right when it matters.
+        """
+        if self._any_tracked_playing:
+            return self.FAST_CHECK_INTERVAL_SECONDS
+        return self.check_interval
     
     def stop_tracking(self) -> None:
         """Stop the background match tracking"""
         self.running = False
         # Save final state to database before stopping
-        asyncio.create_task(self._save_state_to_database())
+        asyncio.create_task(self._save_state_to_database(force=True))
         logging.info("Stopped match tracker")
     
     async def _check_all_servers(self) -> None:
         """Check all servers for recently finished matches"""
+        self._any_tracked_playing = False
         for guild in self.bot.guilds:
             try:
                 await self._check_server_matches(guild)
             except Exception as e:
                 log_error(f"checking server {guild.id}", e)
-    
+
+    @staticmethod
+    def _iter_active_stacks(guild: discord.Guild):
+        """Yield (channel, context, stack_users) for this guild's channels with
+        anyone currently queued.
+
+        Iterates only contexts that already exist in memory — any channel with
+        an active stack has one (created by the command/reaction that filled
+        it). The old approach called get_context() on every text channel in the
+        guild, instantiating a context object (plus a database read) per
+        channel per poll cycle.
+        """
+        for channel_id, context in list(context_manager.contexts.items()):
+            stack_users = context.bot_soloq_user_set.union(context.bot_fullstack_user_set)
+            if not stack_users:
+                continue
+            channel = guild.get_channel(channel_id)
+            if channel is None:
+                continue
+            yield channel, context, stack_users
+
     async def _check_server_matches(self, guild: discord.Guild) -> None:
         """Check a specific server for finished matches by polling members in active shooty stacks"""
         current_time = datetime.now(timezone.utc)
-        members_to_check = []
-        
+        members_to_check = {}
+
         # Find channels with active shooty sessions in this guild
-        for channel in guild.text_channels:
-            context = context_manager.get_context(channel.id)
-            
-            # Get all users in the current stack (soloq + fullstack)
-            all_stack_users = context.bot_soloq_user_set.union(context.bot_fullstack_user_set)
-            
-            # Skip if no one is in the stack
-            if not all_stack_users:
-                continue
-            
+        for _channel, _context, all_stack_users in self._iter_active_stacks(guild):
             # Convert Discord user objects to member objects and check if they have linked accounts
             for user in all_stack_users:
                 # user is a Discord Member object
                 if user.bot:
                     continue
-                    
+
                 accounts = valorant_client.get_all_linked_accounts(user.id)
                 if not accounts:
                     continue
-                
+
+                # A queued member with the game open means a match could finish
+                # soon — switch the loop to the fast poll interval.
+                if valorant_client.is_playing_valorant(user):
+                    self._any_tracked_playing = True
+
                 # Update last checked time
                 if user.id not in self.tracked_members:
                     self.tracked_members[user.id] = {
@@ -152,14 +196,12 @@ class MatchTracker:
                     }
                 else:
                     self.tracked_members[user.id]['last_checked'] = current_time
-                
-                # Add to check list if not already added
-                if user not in members_to_check:
-                    members_to_check.append(user)
-        
+
+                members_to_check.setdefault(user.id, user)
+
         if members_to_check:
             logging.debug(f"Checking {len(members_to_check)} stack members for new matches in {guild.name}")
-            await self._check_recent_matches(guild, members_to_check)
+            await self._check_recent_matches(guild, list(members_to_check.values()))
         else:
             logging.debug(f"No active stack members with linked Valorant accounts in {guild.name}")
     
@@ -173,18 +215,33 @@ class MatchTracker:
         server_matches = self.recent_matches.setdefault(guild.id, {})
         cutoff_time = datetime.now(timezone.utc) - timedelta(hours=self.MATCH_CUTOFF_HOURS)
 
+        # Resolve accounts first, then poll every member concurrently: cycle
+        # time stays ~one API round-trip instead of stack_size round-trips.
+        # force_refresh bypasses the 60s response cache — the poll itself is
+        # the freshness driver, and a cached hit would only delay detection.
+        polled = []
         for member in members:
-            try:
-                primary_account = valorant_client.get_linked_account(member.id)
-                if not primary_account:
-                    continue
+            primary_account = valorant_client.get_linked_account(member.id)
+            if primary_account:
+                polled.append((member, primary_account))
 
-                # Cheap poll: recent competitive match ids + timestamps only
-                updates = await valorant_client.get_recent_competitive_updates(
-                    primary_account['username'],
-                    primary_account['tag'],
-                    puuid=primary_account.get('puuid')
+        results = await asyncio.gather(
+            *(
+                valorant_client.get_recent_competitive_updates(
+                    account['username'],
+                    account['tag'],
+                    puuid=account.get('puuid'),
+                    force_refresh=True,
                 )
+                for _member, account in polled
+            ),
+            return_exceptions=True,
+        )
+
+        for (member, _account), updates in zip(polled, results):
+            try:
+                if isinstance(updates, BaseException):
+                    raise updates
 
                 if not updates:
                     continue
@@ -200,7 +257,9 @@ class MatchTracker:
 
                 if last_known_match != latest_match_id:
                     # Update the last known match for this member
-                    self.tracked_members[member.id]['last_match_id'] = latest_match_id
+                    entry = self.tracked_members.setdefault(member.id, {'last_checked': None})
+                    entry['last_match_id'] = latest_match_id
+                    self._state_dirty = True
 
                     # Skip if we've already processed this match globally
                     if latest_match_id in server_matches:
@@ -260,26 +319,28 @@ class MatchTracker:
     async def _find_discord_members_in_match(self, guild: discord.Guild, match: dict) -> List[Dict]:
         """Find which Discord members were in a specific match"""
         discord_members = []
-        all_players = match.get('players', {}).get('all_players', [])
-        
+        # Index the match's 10 players once, then a single pass over guild
+        # members' linked accounts — instead of scanning the player list per
+        # account per member.
+        players_by_puuid = {
+            player.get('puuid'): player
+            for player in match.get('players', {}).get('all_players', [])
+            if player.get('puuid')
+        }
+
         for member in guild.members:
             if member.bot:
                 continue
-                
-            accounts = valorant_client.get_all_linked_accounts(member.id)
-            for account in accounts:
-                puuid = account.get('puuid', '')
-                
-                # Find this player in the match
-                for player in all_players:
-                    if player.get('puuid') == puuid:
-                        discord_members.append({
-                            'member': member,
-                            'account': account,
-                            'player_data': player
-                        })
-                        break
-        
+
+            for account in valorant_client.get_all_linked_accounts(member.id):
+                player = players_by_puuid.get(account.get('puuid', ''))
+                if player is not None:
+                    discord_members.append({
+                        'member': member,
+                        'account': account,
+                        'player_data': player
+                    })
+
         return discord_members
     
     async def _send_match_results(self, guild: discord.Guild, match: Dict[str, Any], discord_members: List[Dict[str, Any]], game_number: int = 1) -> None:
@@ -288,12 +349,7 @@ class MatchTracker:
         target_channels = []
 
         # Determine which channels have these members queued
-        for channel in guild.text_channels:
-            context = context_manager.get_context(channel.id)
-            all_stack_users = context.bot_soloq_user_set.union(context.bot_fullstack_user_set)
-            if not all_stack_users:
-                continue
-
+        for channel, _context, all_stack_users in self._iter_active_stacks(guild):
             participants = [dm for dm in discord_members if dm['member'] in all_stack_users]
             if len(participants) >= self.MIN_DISCORD_MEMBERS:
                 target_channels.append(channel)
@@ -639,13 +695,12 @@ class MatchTracker:
         Best-effort: silently skips members whose MMR can't be fetched (private
         profile, API down, no key), so the recap still renders without them.
         """
-        ranked_up = set()
-        for dm in discord_members:
+        async def check_member(dm) -> Optional[int]:
             account = dm.get('account', {}) or {}
             username = account.get('username')
             tag = account.get('tag')
             if not username or not tag:
-                continue
+                return None
 
             rr = None
             change = None
@@ -681,9 +736,16 @@ class MatchTracker:
                     change = mmr.get('rr_change')
 
             if self._is_full_tier_promotion(rr, change):
-                ranked_up.add(dm['member'].id)
+                return dm['member'].id
+            return None
 
-        return ranked_up
+        # These fetches sit between match detection and the recap being
+        # posted — run them concurrently so the announcement isn't delayed by
+        # squad_size sequential round-trips.
+        results = await asyncio.gather(
+            *(check_member(dm) for dm in discord_members), return_exceptions=True
+        )
+        return {mid for mid in results if isinstance(mid, int)}
 
     async def build_session_recap(self, guild: discord.Guild, participants: List[discord.Member], session) -> discord.Embed:
         """Build an end-of-session recap embed.
@@ -711,36 +773,44 @@ class MatchTracker:
         matches_by_id: Dict[str, Dict[str, Any]] = {}
         member_puuids: Dict[str, discord.Member] = {}
 
+        recap_accounts = []
         for member in participants:
             if getattr(member, 'bot', False):
                 continue
-            accounts = valorant_client.get_all_linked_accounts(member.id)
-            for account in accounts:
+            for account in valorant_client.get_all_linked_accounts(member.id):
                 puuid = account.get('puuid')
                 if puuid:
                     member_puuids[puuid] = member
-                try:
-                    updates = await valorant_client.get_recent_competitive_updates(
-                        account['username'], account['tag'], puuid=puuid
-                    )
-                except Exception as e:
-                    log_error(f"fetching session matches for {account.get('username')}", e)
-                    updates = None
+                recap_accounts.append(account)
 
-                for update in updates or []:
-                    mid = update.get('match_id')
-                    if not mid or mid in matches_by_id:
-                        continue
-                    started = update.get('started_at')
-                    if started is None:
-                        continue
-                    if window_start and started < window_start:
-                        continue
-                    if started > window_end:
-                        continue
-                    match = await valorant_client.get_match_details(mid)
-                    if match:
-                        matches_by_id[mid] = match
+        async def fetch_updates(account):
+            try:
+                return await valorant_client.get_recent_competitive_updates(
+                    account['username'], account['tag'], puuid=account.get('puuid')
+                )
+            except Exception as e:
+                log_error(f"fetching session matches for {account.get('username')}", e)
+                return None
+
+        # Discover every account's recent matches concurrently; detail lookups
+        # below are mostly SQLite cache hits (the tracker stored them live).
+        all_updates = await asyncio.gather(*(fetch_updates(a) for a in recap_accounts))
+
+        for updates in all_updates:
+            for update in updates or []:
+                mid = update.get('match_id')
+                if not mid or mid in matches_by_id:
+                    continue
+                started = update.get('started_at')
+                if started is None:
+                    continue
+                if window_start and started < window_start:
+                    continue
+                if started > window_end:
+                    continue
+                match = await valorant_client.get_match_details(mid)
+                if match:
+                    matches_by_id[mid] = match
 
         # Warm the per-match stat rows for everyone we fetched details for
         for match in matches_by_id.values():
@@ -839,17 +909,23 @@ class MatchTracker:
                 inline=False
             )
 
-        # End-of-night ranks (best-effort)
+        # End-of-night ranks (best-effort), fetched concurrently
         rank_lines = []
+        rank_targets = []
         for member in participants:
             account = valorant_client.get_linked_account(member.id)
-            if not account:
-                continue
+            if account:
+                rank_targets.append((member, account))
+
+        async def fetch_mmr(account):
             try:
-                mmr = await valorant_client.get_mmr(account['username'], account['tag'],
-                                                    puuid=account.get('puuid'))
+                return await valorant_client.get_mmr(account['username'], account['tag'],
+                                                     puuid=account.get('puuid'))
             except Exception:
-                mmr = None
+                return None
+
+        mmrs = await asyncio.gather(*(fetch_mmr(account) for _member, account in rank_targets))
+        for (member, _account), mmr in zip(rank_targets, mmrs):
             if mmr and mmr.get('tier'):
                 rr = mmr.get('rr')
                 rr_str = f" · {rr} RR" if rr is not None else ""
@@ -1624,56 +1700,55 @@ class MatchTracker:
             match_timestamp = datetime.now(timezone.utc)
         
         # Find which channels have these members in their stacks
-        for channel in guild.text_channels:
-            context = context_manager.get_context(channel.id)
-            all_stack_users = context.bot_soloq_user_set.union(context.bot_fullstack_user_set)
-            
-            if not all_stack_users:
-                continue
-            
+        for channel, _context, all_stack_users in self._iter_active_stacks(guild):
             # Check if any of the match participants are in this channel's stack
             stack_members_in_match = []
             for dm in discord_members_in_match:
                 if dm['member'] in all_stack_users:
                     stack_members_in_match.append(dm['member'])
-            
+
             # If stack members were in this match, update activity
             if len(stack_members_in_match) >= self.MIN_DISCORD_MEMBERS:
                 self.stack_last_activity[channel.id] = match_timestamp
                 self.stack_has_played[channel.id] = True
+                self._state_dirty = True
                 logging.info(f"Updated activity for stack in channel {channel.id} - {len(stack_members_in_match)} members played")
     
     async def _check_inactive_stacks(self) -> None:
-        """Check for stacks that have been inactive and auto-end them"""
+        """Check for stacks that have been inactive and auto-end them.
+
+        Walks only the contexts already in memory instead of every text channel
+        in every guild — a channel with a live stack always has a context.
+        """
         current_time = datetime.now(timezone.utc)
         inactivity_cutoff = timedelta(hours=self.STACK_INACTIVITY_HOURS)
-        
-        for guild in self.bot.guilds:
+
+        for channel_id, context in list(context_manager.contexts.items()):
             try:
-                for channel in guild.text_channels:
-                    context = context_manager.get_context(channel.id)
-                    all_stack_users = context.bot_soloq_user_set.union(context.bot_fullstack_user_set)
-                    
-                    # Skip if no one is in the stack
-                    if not all_stack_users:
-                        # Clean up tracking data for empty stacks
-                        if channel.id in self.stack_last_activity:
-                            del self.stack_last_activity[channel.id]
-                        if channel.id in self.stack_has_played:
-                            del self.stack_has_played[channel.id]
-                        continue
-                    
-                    # Only check stacks that have had gaming activity
-                    if not self.stack_has_played.get(channel.id, False):
-                        continue
-                    
-                    # Check if stack has been inactive
-                    last_activity = self.stack_last_activity.get(channel.id)
-                    if last_activity and (current_time - last_activity) > inactivity_cutoff:
+                all_stack_users = context.bot_soloq_user_set.union(context.bot_fullstack_user_set)
+
+                # Skip if no one is in the stack
+                if not all_stack_users:
+                    # Clean up tracking data for empty stacks
+                    if self.stack_last_activity.pop(channel_id, None) is not None:
+                        self._state_dirty = True
+                    if self.stack_has_played.pop(channel_id, None) is not None:
+                        self._state_dirty = True
+                    continue
+
+                # Only check stacks that have had gaming activity
+                if not self.stack_has_played.get(channel_id, False):
+                    continue
+
+                # Check if stack has been inactive
+                last_activity = self.stack_last_activity.get(channel_id)
+                if last_activity and (current_time - last_activity) > inactivity_cutoff:
+                    channel = self.bot.get_channel(channel_id)
+                    if channel is not None:
                         await self._auto_end_inactive_stack(channel, context, current_time - last_activity)
-                        
+
             except Exception as e:
-                log_error(f"checking inactive stacks for {guild.id}", e)
+                log_error(f"checking inactive stack for channel {channel_id}", e)
     
     async def _auto_end_inactive_stack(self, channel: discord.TextChannel, context, inactivity_duration: timedelta) -> None:
         """Automatically end an inactive stack"""
@@ -1716,7 +1791,9 @@ class MatchTracker:
                 del self.stack_last_activity[channel.id]
             if channel.id in self.stack_has_played:
                 del self.stack_has_played[channel.id]
-            
+            self._state_dirty = True
+
+
             # Silently end the stack and log the action
             logging.info(
                 f"Auto-ended inactive stack in channel {channel.id} after {inactivity_duration}"
@@ -1818,8 +1895,16 @@ class MatchTracker:
         except Exception as e:
             log_error("loading match tracker state from database", e)
     
-    async def _save_state_to_database(self) -> None:
-        """Save current match tracker state to database"""
+    async def _save_state_to_database(self, force: bool = False) -> None:
+        """Save match tracker state to database when it has changed.
+
+        The poll loop calls this every cycle, but writes only happen after a
+        real state change (new match id, stack activity, auto-end) — an idle
+        cycle costs zero SQLite writes, which matters on the Pi's SD card.
+        ``force=True`` (shutdown path) writes unconditionally.
+        """
+        if not (self._state_dirty or force):
+            return
         try:
             # Save tracked members by server
             servers_processed = set()
@@ -1844,11 +1929,12 @@ class MatchTracker:
             # Save stack states
             for channel_id, has_played in self.stack_has_played.items():
                 last_activity = self.stack_last_activity.get(channel_id)
-                # Get participant count from context if available
-                try:
-                    context = context_manager.get_context(channel_id)
+                # Get participant count from an already-loaded context; don't
+                # instantiate one (plus a DB read) just to report a count
+                context = context_manager.contexts.get(channel_id)
+                if context is not None:
                     participant_count = len(context.bot_soloq_user_set.union(context.bot_fullstack_user_set))
-                except:
+                else:
                     participant_count = 0
                 
                 database_manager.save_stack_state(
@@ -1858,9 +1944,16 @@ class MatchTracker:
                     participant_count=participant_count
                 )
             
-            # Clean up old state data (older than 30 days)
-            database_manager.cleanup_old_tracker_state(days=30)
-            
+            self._state_dirty = False
+
+            # Clean up old state data (older than 30 days), at most once a day
+            # instead of running a DELETE scan every poll cycle
+            now = datetime.now(timezone.utc)
+            if (self._last_state_cleanup is None
+                    or (now - self._last_state_cleanup) > timedelta(hours=self.STATE_CLEANUP_INTERVAL_HOURS)):
+                self._last_state_cleanup = now
+                database_manager.cleanup_old_tracker_state(days=30)
+
         except Exception as e:
             log_error("saving match tracker state to database", e)
     

--- a/tests/unit/test_auto_end_session.py
+++ b/tests/unit/test_auto_end_session.py
@@ -1,0 +1,230 @@
+"""Tests for automatic session ending — /stend is rarely used in practice, so
+the tracker must close sessions (and post the recap) on its own:
+
+- presence-based fast path: end once everyone closed Valorant for a grace period
+- the presence path only arms after presence has actually shown someone in-game
+- the 1.5h inactivity timer remains as the fallback
+- auto-end posts the session recap to the stack channel
+"""
+
+import os
+import sys
+from datetime import datetime, timezone, timedelta
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../..')))
+
+import discord
+
+from match_tracker import MatchTracker
+
+
+def make_member(user_id=1, name='Player'):
+    member = MagicMock(spec=discord.Member)
+    member.id = user_id
+    member.display_name = name
+    member.bot = False
+    return member
+
+
+def make_context(stack_users, session_id='sess-1'):
+    context = MagicMock()
+    context.bot_soloq_user_set = set(stack_users)
+    context.bot_fullstack_user_set = set()
+    context.current_session_id = session_id
+    return context
+
+
+def make_tracker():
+    bot = MagicMock(spec=discord.Client)
+    bot.guilds = []
+    bot.get_channel = MagicMock()
+    bot.get_cog = MagicMock()
+    return MatchTracker(bot)
+
+
+class TestPresenceBasedAutoEnd:
+    @pytest.mark.asyncio
+    async def test_ends_after_everyone_offline_for_grace_period(self):
+        tracker = make_tracker()
+        member = make_member()
+        context = make_context([member])
+        channel = MagicMock()
+        channel.id = 123
+        tracker.bot.get_channel.return_value = channel
+
+        tracker.stack_has_played[123] = True
+        tracker._auto_end_inactive_stack = AsyncMock()
+
+        mock_cm = MagicMock()
+        mock_cm.contexts = {123: context}
+
+        with patch('match_tracker.context_manager', mock_cm), \
+                patch('match_tracker.valorant_client') as mock_client:
+            # Cycle 1: someone is in-game — presence path arms, no end
+            mock_client.is_playing_valorant.return_value = True
+            await tracker._check_inactive_stacks()
+            assert tracker.stack_seen_playing.get(123) is True
+            tracker._auto_end_inactive_stack.assert_not_awaited()
+
+            # Cycle 2: everyone closed Valorant — grace period starts, no end yet
+            mock_client.is_playing_valorant.return_value = False
+            await tracker._check_inactive_stacks()
+            assert 123 in tracker.stack_offline_since
+            tracker._auto_end_inactive_stack.assert_not_awaited()
+
+            # Cycle 3: grace period elapsed — session ends
+            tracker.stack_offline_since[123] = (
+                datetime.now(timezone.utc)
+                - timedelta(minutes=MatchTracker.STACK_OFFLINE_END_MINUTES + 1))
+            await tracker._check_inactive_stacks()
+            tracker._auto_end_inactive_stack.assert_awaited_once()
+            assert tracker._auto_end_inactive_stack.await_args.kwargs['reason'] == 'everyone offline'
+
+    @pytest.mark.asyncio
+    async def test_coming_back_online_resets_the_grace_period(self):
+        tracker = make_tracker()
+        member = make_member()
+        context = make_context([member])
+        tracker.stack_has_played[123] = True
+        tracker.stack_seen_playing[123] = True
+        tracker.stack_offline_since[123] = (
+            datetime.now(timezone.utc) - timedelta(minutes=15))
+        tracker._auto_end_inactive_stack = AsyncMock()
+
+        mock_cm = MagicMock()
+        mock_cm.contexts = {123: context}
+
+        with patch('match_tracker.context_manager', mock_cm), \
+                patch('match_tracker.valorant_client') as mock_client:
+            # A member relaunched the game — the offline clock must reset
+            mock_client.is_playing_valorant.return_value = True
+            await tracker._check_inactive_stacks()
+
+            assert 123 not in tracker.stack_offline_since
+            tracker._auto_end_inactive_stack.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_never_arms_without_seeing_presence(self):
+        """Hidden/broken presence must not end sessions early — the stack just
+        falls back to the long inactivity timer."""
+        tracker = make_tracker()
+        member = make_member()
+        context = make_context([member])
+        tracker.stack_has_played[123] = True
+        tracker._auto_end_inactive_stack = AsyncMock()
+
+        mock_cm = MagicMock()
+        mock_cm.contexts = {123: context}
+
+        with patch('match_tracker.context_manager', mock_cm), \
+                patch('match_tracker.valorant_client') as mock_client:
+            mock_client.is_playing_valorant.return_value = False
+            await tracker._check_inactive_stacks()
+            await tracker._check_inactive_stacks()
+
+            assert 123 not in tracker.stack_offline_since
+            tracker._auto_end_inactive_stack.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_inactivity_timer_still_fires_as_fallback(self):
+        tracker = make_tracker()
+        member = make_member()
+        context = make_context([member])
+        channel = MagicMock()
+        channel.id = 123
+        tracker.bot.get_channel.return_value = channel
+
+        tracker.stack_has_played[123] = True
+        tracker.stack_last_activity[123] = (
+            datetime.now(timezone.utc)
+            - timedelta(hours=MatchTracker.STACK_INACTIVITY_HOURS + 0.1))
+        tracker._auto_end_inactive_stack = AsyncMock()
+
+        mock_cm = MagicMock()
+        mock_cm.contexts = {123: context}
+
+        with patch('match_tracker.context_manager', mock_cm), \
+                patch('match_tracker.valorant_client') as mock_client:
+            mock_client.is_playing_valorant.return_value = False
+            await tracker._check_inactive_stacks()
+
+            tracker._auto_end_inactive_stack.assert_awaited_once()
+            assert tracker._auto_end_inactive_stack.await_args.kwargs['reason'] == 'inactivity'
+
+
+class TestAutoEndPostsRecap:
+    @pytest.mark.asyncio
+    async def test_auto_end_ends_session_and_posts_recap(self):
+        tracker = make_tracker()
+        member = make_member()
+        context = make_context([member], session_id='sess-1')
+        channel = MagicMock()
+        channel.id = 123
+        channel.guild = MagicMock()
+        channel.send = AsyncMock()
+
+        session_cog = MagicMock()
+        session_cog._end_current_session = AsyncMock()
+        tracker.bot.get_cog.return_value = session_cog
+
+        recap_embed = MagicMock(spec=discord.Embed)
+        tracker.build_session_recap = AsyncMock(return_value=recap_embed)
+
+        fake_session = MagicMock()
+        mock_dm = MagicMock()
+        mock_dm.sessions.get.return_value = fake_session
+
+        with patch('data_manager.data_manager', mock_dm):
+            await tracker._auto_end_inactive_stack(
+                channel, context, timedelta(minutes=25), reason='everyone offline')
+
+        # Session ended through the cog (records stats), recap posted with the
+        # participants captured before the stack was reset
+        session_cog._end_current_session.assert_awaited_once_with(context)
+        tracker.build_session_recap.assert_awaited_once()
+        assert tracker.build_session_recap.await_args.args[1] == [member]
+        assert tracker.build_session_recap.await_args.args[2] is fake_session
+        channel.send.assert_awaited_once()
+        assert channel.send.await_args.kwargs['embed'] is recap_embed
+
+    @pytest.mark.asyncio
+    async def test_recap_failure_does_not_break_auto_end(self):
+        tracker = make_tracker()
+        member = make_member()
+        context = make_context([member])
+        channel = MagicMock()
+        channel.id = 123
+        channel.guild = MagicMock()
+        channel.send = AsyncMock()
+
+        session_cog = MagicMock()
+        session_cog._end_current_session = AsyncMock()
+        tracker.bot.get_cog.return_value = session_cog
+
+        tracker.build_session_recap = AsyncMock(side_effect=RuntimeError('API down'))
+        tracker.stack_has_played[123] = True
+
+        fake_session = MagicMock()
+        mock_dm = MagicMock()
+        mock_dm.sessions.get.return_value = fake_session
+
+        with patch('data_manager.data_manager', mock_dm):
+            # Must not raise; stack cleanup still happens
+            await tracker._auto_end_inactive_stack(channel, context, timedelta(hours=2))
+
+        session_cog._end_current_session.assert_awaited_once()
+        assert 123 not in tracker.stack_has_played
+
+    @pytest.mark.asyncio
+    async def test_no_participants_means_no_recap(self):
+        tracker = make_tracker()
+        channel = MagicMock()
+        channel.id = 123
+        channel.send = AsyncMock()
+
+        await tracker._send_auto_end_recap(channel, 'sess-1', [])
+
+        channel.send.assert_not_awaited()

--- a/tests/unit/test_match_tracker_perf.py
+++ b/tests/unit/test_match_tracker_perf.py
@@ -1,0 +1,295 @@
+"""Tests for the match tracker's performance behavior:
+
+- polling only iterates already-loaded contexts (no per-channel context churn)
+- adaptive poll interval driven by Discord presence
+- per-member polls fan out concurrently and still dedupe shared matches
+- tracker state is persisted only when it actually changed (SD-card friendly)
+"""
+
+import os
+import sys
+from datetime import datetime, timezone, timedelta
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../..')))
+
+import discord
+
+from match_tracker import MatchTracker
+
+
+def make_member(user_id=1, name='Player'):
+    member = MagicMock(spec=discord.Member)
+    member.id = user_id
+    member.display_name = name
+    member.bot = False
+    return member
+
+
+def make_context(stack_users):
+    context = MagicMock()
+    context.bot_soloq_user_set = set(stack_users)
+    context.bot_fullstack_user_set = set()
+    return context
+
+
+def make_tracker():
+    bot = MagicMock(spec=discord.Client)
+    bot.guilds = []
+    return MatchTracker(bot)
+
+
+class TestActiveStackIteration:
+    @pytest.mark.asyncio
+    async def test_poll_does_not_instantiate_contexts(self):
+        """The poll must only look at contexts already in memory — never call
+        get_context(), which creates a context (plus a DB read) per channel."""
+        tracker = make_tracker()
+        guild = MagicMock(spec=discord.Guild)
+        guild.id = 1
+        guild.name = 'Guild'
+
+        member = make_member()
+        channel = MagicMock()
+        channel.id = 123
+        guild.get_channel.return_value = channel
+
+        mock_cm = MagicMock()
+        mock_cm.contexts = {123: make_context([member])}
+
+        tracker._check_recent_matches = AsyncMock()
+
+        with patch('match_tracker.context_manager', mock_cm), \
+                patch('match_tracker.valorant_client') as mock_client:
+            mock_client.get_all_linked_accounts.return_value = [{'puuid': 'p1'}]
+            mock_client.is_playing_valorant.return_value = False
+
+            await tracker._check_server_matches(guild)
+
+            mock_cm.get_context.assert_not_called()
+            tracker._check_recent_matches.assert_awaited_once_with(guild, [member])
+
+    @pytest.mark.asyncio
+    async def test_contexts_from_other_guilds_are_skipped(self):
+        tracker = make_tracker()
+        guild = MagicMock(spec=discord.Guild)
+        guild.id = 1
+        guild.name = 'Guild'
+        guild.get_channel.return_value = None  # channel not in this guild
+
+        mock_cm = MagicMock()
+        mock_cm.contexts = {456: make_context([make_member()])}
+
+        tracker._check_recent_matches = AsyncMock()
+
+        with patch('match_tracker.context_manager', mock_cm), \
+                patch('match_tracker.valorant_client') as mock_client:
+            mock_client.get_all_linked_accounts.return_value = [{'puuid': 'p1'}]
+            mock_client.is_playing_valorant.return_value = False
+
+            await tracker._check_server_matches(guild)
+
+            tracker._check_recent_matches.assert_not_awaited()
+
+
+class TestAdaptivePollInterval:
+    def test_interval_selection(self):
+        tracker = make_tracker()
+        tracker._any_tracked_playing = False
+        assert tracker._current_check_interval() == MatchTracker.CHECK_INTERVAL_SECONDS
+        tracker._any_tracked_playing = True
+        assert tracker._current_check_interval() == MatchTracker.FAST_CHECK_INTERVAL_SECONDS
+        assert (MatchTracker.FAST_CHECK_INTERVAL_SECONDS
+                < MatchTracker.CHECK_INTERVAL_SECONDS)
+
+    @pytest.mark.asyncio
+    async def test_presence_sets_fast_polling_flag(self):
+        tracker = make_tracker()
+        guild = MagicMock(spec=discord.Guild)
+        guild.id = 1
+        guild.name = 'Guild'
+
+        member = make_member()
+        channel = MagicMock()
+        channel.id = 123
+        guild.get_channel.return_value = channel
+
+        mock_cm = MagicMock()
+        mock_cm.contexts = {123: make_context([member])}
+
+        tracker._check_recent_matches = AsyncMock()
+
+        with patch('match_tracker.context_manager', mock_cm), \
+                patch('match_tracker.valorant_client') as mock_client:
+            mock_client.get_all_linked_accounts.return_value = [{'puuid': 'p1'}]
+
+            mock_client.is_playing_valorant.return_value = True
+            tracker._any_tracked_playing = False
+            await tracker._check_server_matches(guild)
+            assert tracker._any_tracked_playing is True
+
+            mock_client.is_playing_valorant.return_value = False
+            tracker._any_tracked_playing = False
+            await tracker._check_server_matches(guild)
+            assert tracker._any_tracked_playing is False
+
+
+class TestConcurrentPolling:
+    @pytest.mark.asyncio
+    async def test_shared_match_still_processed_once(self):
+        """Two stack members finishing the same game must produce exactly one
+        detail fetch and one announcement, even with concurrent polls."""
+        tracker = make_tracker()
+        guild = MagicMock(spec=discord.Guild)
+        guild.id = 1
+
+        m1 = make_member(1, 'One')
+        m2 = make_member(2, 'Two')
+        match = {'metadata': {'matchid': 'shared', 'game_length': 2400},
+                 'players': {'all_players': []}}
+
+        with patch('match_tracker.valorant_client') as mock_client:
+            mock_client.get_linked_account.side_effect = lambda uid: {
+                'username': f'U{uid}', 'tag': 'TAG', 'puuid': f'p{uid}'}
+            mock_client.get_recent_competitive_updates = AsyncMock(return_value=[
+                {'match_id': 'shared', 'started_at': datetime.now(timezone.utc),
+                 'rr_change': 10}
+            ])
+            mock_client.get_match_details = AsyncMock(return_value=match)
+            mock_client.record_match_stats_for_players = MagicMock(return_value=2)
+
+            discord_members = [
+                {'member': m1, 'account': {'puuid': 'p1'}, 'player_data': {}},
+                {'member': m2, 'account': {'puuid': 'p2'}, 'player_data': {}},
+            ]
+            tracker._find_discord_members_in_match = AsyncMock(return_value=discord_members)
+            tracker._send_match_results = AsyncMock()
+            tracker._update_stack_activity = AsyncMock()
+
+            await tracker._check_recent_matches(guild, [m1, m2])
+
+            mock_client.get_match_details.assert_awaited_once_with('shared')
+            tracker._send_match_results.assert_awaited_once()
+            # Both members now know about the match id, and state is dirty so
+            # it gets persisted this cycle
+            assert tracker.tracked_members[m1.id]['last_match_id'] == 'shared'
+            assert tracker.tracked_members[m2.id]['last_match_id'] == 'shared'
+            assert tracker._state_dirty is True
+
+    @pytest.mark.asyncio
+    async def test_poll_bypasses_response_cache(self):
+        """The tracker's poll must ask for fresh data — a cached mmr-history
+        response would only delay detection of a finished game."""
+        tracker = make_tracker()
+        guild = MagicMock(spec=discord.Guild)
+        guild.id = 1
+        member = make_member()
+
+        with patch('match_tracker.valorant_client') as mock_client:
+            mock_client.get_linked_account.return_value = {
+                'username': 'U', 'tag': 'TAG', 'puuid': 'p1'}
+            mock_client.get_recent_competitive_updates = AsyncMock(return_value=[])
+
+            await tracker._check_recent_matches(guild, [member])
+
+            kwargs = mock_client.get_recent_competitive_updates.await_args.kwargs
+            assert kwargs.get('force_refresh') is True
+
+    @pytest.mark.asyncio
+    async def test_one_failing_member_does_not_block_others(self):
+        tracker = make_tracker()
+        guild = MagicMock(spec=discord.Guild)
+        guild.id = 1
+
+        m1 = make_member(1, 'One')
+        m2 = make_member(2, 'Two')
+        match = {'metadata': {'matchid': 'new', 'game_length': 2400},
+                 'players': {'all_players': []}}
+
+        with patch('match_tracker.valorant_client') as mock_client:
+            mock_client.get_linked_account.side_effect = lambda uid: {
+                'username': f'U{uid}', 'tag': 'TAG', 'puuid': f'p{uid}'}
+
+            async def updates_for(username, tag, **kwargs):
+                if username == 'U1':
+                    raise RuntimeError('API blew up')
+                return [{'match_id': 'new',
+                         'started_at': datetime.now(timezone.utc), 'rr_change': 5}]
+
+            mock_client.get_recent_competitive_updates = AsyncMock(side_effect=updates_for)
+            mock_client.get_match_details = AsyncMock(return_value=match)
+            mock_client.record_match_stats_for_players = MagicMock(return_value=1)
+
+            tracker._find_discord_members_in_match = AsyncMock(return_value=[
+                {'member': m2, 'account': {'puuid': 'p2'}, 'player_data': {}},
+                {'member': make_member(3), 'account': {'puuid': 'p3'}, 'player_data': {}},
+            ])
+            tracker._send_match_results = AsyncMock()
+            tracker._update_stack_activity = AsyncMock()
+
+            await tracker._check_recent_matches(guild, [m1, m2])
+
+            # Member 2's new match is still detected and announced
+            tracker._send_match_results.assert_awaited_once()
+
+
+class TestDirtyGatedStateSaves:
+    @pytest.mark.asyncio
+    async def test_clean_state_writes_nothing(self):
+        tracker = make_tracker()
+        with patch('match_tracker.database_manager') as mock_db:
+            await tracker._save_state_to_database()
+
+            mock_db.save_match_tracker_state.assert_not_called()
+            mock_db.save_stack_state.assert_not_called()
+            mock_db.cleanup_old_tracker_state.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_dirty_state_is_saved_then_marked_clean(self):
+        tracker = make_tracker()
+        tracker._state_dirty = True
+        tracker.stack_has_played[123] = True
+        tracker.stack_last_activity[123] = datetime.now(timezone.utc)
+
+        with patch('match_tracker.database_manager') as mock_db:
+            await tracker._save_state_to_database()
+
+            mock_db.save_stack_state.assert_called_once()
+            assert tracker._state_dirty is False
+
+            # Next cycle: nothing changed, nothing written
+            await tracker._save_state_to_database()
+            mock_db.save_stack_state.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_force_save_ignores_dirty_flag(self):
+        tracker = make_tracker()
+        tracker.stack_has_played[123] = True
+
+        with patch('match_tracker.database_manager') as mock_db:
+            await tracker._save_state_to_database(force=True)
+            mock_db.save_stack_state.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_cleanup_runs_at_most_daily(self):
+        tracker = make_tracker()
+
+        with patch('match_tracker.database_manager') as mock_db:
+            tracker._state_dirty = True
+            await tracker._save_state_to_database()
+            assert mock_db.cleanup_old_tracker_state.call_count == 1
+
+            # A second dirty save right after must not re-run the cleanup scan
+            tracker._state_dirty = True
+            await tracker._save_state_to_database()
+            assert mock_db.cleanup_old_tracker_state.call_count == 1
+
+            # ...but it runs again once a day has passed
+            tracker._last_state_cleanup = (
+                datetime.now(timezone.utc)
+                - timedelta(hours=MatchTracker.STATE_CLEANUP_INTERVAL_HOURS + 1))
+            tracker._state_dirty = True
+            await tracker._save_state_to_database()
+            assert mock_db.cleanup_old_tracker_state.call_count == 2


### PR DESCRIPTION
## Summary

Two commits: performance work on the match-tracker polling path (the key latency between a game ending and the recap posting), plus making session end + session recap fully automatic instead of depending on `/stend`.

### Match-detection latency (`5b0a9ee`)

- **Adaptive poll interval**: 30s while any queued member's Discord presence shows Valorant open (free gateway data), 60s otherwise — the faster spend happens only in the window where a match can actually finish.
- **Concurrent polling**: all stack members' mmr-history fetches fan out through one `asyncio.gather`, so a poll cycle costs ~one API round-trip instead of stack_size sequential round-trips. Shared-match dedupe is preserved, and one member's API failure no longer blocks the others.
- **Fresh polls**: the tracker passes `force_refresh=True` — the 60s response cache only added up to a minute of staleness on top of the interval.
- **Faster announcements**: rank-up checks, session-recap match discovery, and end-of-night rank fetches also run concurrently.

### Idle I/O on the Pi (`5b0a9ee`)

- Tracker state is persisted only when it actually changed (new match id, stack activity, auto-end) instead of writing every user row + stack state every 60s; the 30-day cleanup `DELETE` runs at most daily instead of every cycle. Idle cycles do zero SD-card writes.
- The tracker iterates only in-memory contexts with queued members instead of calling `get_context()` on every text channel per guild per cycle (each miss created a context object plus a SQLite read).
- `_find_discord_members_in_match` indexes match players by puuid once instead of nested scans.

### Automatic session end + recap (`2d1678b`)

`/stend` is essentially never used, and the session recap was only wired to it — the auto-end path ended sessions silently after 1.5h.

- Auto-end now posts the full session recap (scoreboard, MVP, W/L, ranks) to the stack's channel.
- New presence-based fast path: once a stack has played and presence has shown members in-game, the session ends ~20 min (`STACK_OFFLINE_END_MINUTES`) after everyone closes Valorant. Self-validating — it only arms after presence has been seen working for that stack, so hidden/broken presence falls back to the 1.5h timer rather than ending early. Relaunching during the grace period resets the clock.

## Testing

- 18 new unit tests (`test_match_tracker_perf.py`, `test_auto_end_session.py`) covering concurrent-poll dedupe, error isolation, adaptive interval, dirty-gated saves, presence arming/reset, fallback timer, and recap posting.
- Full unit suite green: 291 passed, 3 skipped. The 5 `tests/integration/test_match_stats.py` errors are pre-existing (require live Henrik API access, unavailable in the sandbox) and occur identically on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014CVrW5HQaBH6favMK5b6Qp

---
_Generated by [Claude Code](https://claude.ai/code/session_014CVrW5HQaBH6favMK5b6Qp)_