### PR TITLE
Include unlinked teammates in match highlights and session recap

### DIFF
--- a/match_tracker.py
+++ b/match_tracker.py
@@ -13,6 +13,21 @@ from match_stats_display import (
     recap_view,
 )
 
+class UnlinkedPlayer:
+    """Stand-in for a squad teammate who hasn't linked a Discord account.
+
+    Exposes the same ``display_name``/``id`` surface the recap and highlight
+    code reads off ``discord.Member``, so everyone in the game flows through
+    one pipeline. ``id`` is the player's puuid (a string), which can never
+    collide with a real Discord member id (an int).
+    """
+    __slots__ = ('display_name', 'id')
+
+    def __init__(self, name: str, tag: str, puuid: Optional[str]) -> None:
+        self.display_name = f"{name}#{tag}" if tag else name
+        self.id = puuid or self.display_name
+
+
 class MatchTracker:
     """Tracks Discord members' Valorant matches by polling for newly completed games in active shooty stacks"""
     
@@ -352,7 +367,40 @@ class MatchTracker:
                     })
 
         return discord_members
-    
+
+    @staticmethod
+    def _unlinked_teammates(match: dict, discord_members: List[Dict]) -> List[Dict]:
+        """Same-team players who aren't linked via /shootylink, in the same
+        dict shape as ``discord_members`` entries (member/account/player_data)
+        so recaps and highlights treat everyone in the game uniformly. The
+        squad's team comes from the linked members' player data."""
+        tracked_puuids = set()
+        team_color = None
+        for dm in discord_members:
+            puuid = dm.get('account', {}).get('puuid') or (dm.get('player_data') or {}).get('puuid')
+            if puuid:
+                tracked_puuids.add(puuid)
+            if not team_color:
+                team_color = ((dm.get('player_data') or {}).get('team') or '').lower()
+
+        if not team_color:
+            return []
+
+        unlinked = []
+        for player in match.get('players', {}).get('all_players', []):
+            if (player.get('team') or '').lower() != team_color:
+                continue
+            if player.get('puuid') in tracked_puuids:
+                continue
+            shim = UnlinkedPlayer(player.get('name', 'Unknown'), player.get('tag', ''),
+                                  player.get('puuid'))
+            unlinked.append({
+                'member': shim,
+                'account': {'puuid': player.get('puuid')},
+                'player_data': player
+            })
+        return unlinked
+
     async def _send_match_results(self, guild: discord.Guild, match: Dict[str, Any], discord_members: List[Dict[str, Any]], game_number: int = 1) -> None:
         """Send match results to relevant stack channels"""
 
@@ -428,8 +476,13 @@ class MatchTracker:
         if match_id:
             tracker_link = f"[📊 View on Tracker.gg](https://tracker.gg/valorant/match/{match_id})"
 
-        # Calculate fun stats
-        fun_stats = self._calculate_fun_match_stats(match, discord_members)
+        # Unlinked teammates (same team, no /shootylink) join the linked
+        # members everywhere below — squad list, roll-up and highlights — so
+        # the recap covers everyone who actually played with the stack.
+        unlinked_members = self._unlinked_teammates(match, discord_members)
+
+        # Calculate fun stats across the whole squad, not just linked members
+        fun_stats = self._calculate_fun_match_stats(match, discord_members + unlinked_members)
 
         # Figure out which side the stack played on (all squad members are
         # together) so the whole recap can be framed from their perspective.
@@ -497,43 +550,24 @@ class MatchTracker:
         # most useful per-round numbers (ACS, ADR); the top ACS in the squad
         # gets a 👑, and a one-line summary rolls the squad up.
         entries = []  # (display_name, stats, rank_str, rankup_str)
-        tracked_puuids = set()
 
         # Members who crossed up a full tier this game (shown inline)
         ranked_up_ids = await self._get_ranked_up_member_ids(
             discord_members, match_id=match_id or None
         )
 
-        for dm in discord_members:
+        # Linked members first (by Discord name), then unlinked teammates
+        # (by in-game name#tag) — everyone gets the same stat line.
+        for dm in discord_members + unlinked_members:
             member = dm['member']
             player_data = dm['player_data']
             puuid = dm.get('account', {}).get('puuid') or player_data.get('puuid')
-            if puuid:
-                tracked_puuids.add(puuid)
 
             pstats = player_display_stats(match, player_data, puuid)
             rank = get_player_rank(player_data)
             rank_str = f" • {rank_emoji(rank)} {rank}" if rank else ""
             rankup_str = " ⬆️ **Rank Up!**" if member.id in ranked_up_ids else ""
             entries.append((member.display_name, pstats, rank_str, rankup_str))
-
-        # Add untracked teammates (players on the same team who aren't linked via shootylink)
-        all_players = match.get('players', {}).get('all_players', [])
-        untracked_count = 0
-        if team_color:
-            for player in all_players:
-                if player.get('team', '').lower() != team_color:
-                    continue
-                if player.get('puuid') in tracked_puuids:
-                    continue
-                name = player.get('name', 'Unknown')
-                tag = player.get('tag', '')
-                display_name = f"{name}#{tag}" if tag else name
-                pstats = player_display_stats(match, player, player.get('puuid'))
-                rank = get_player_rank(player)
-                rank_str = f" • {rank_emoji(rank)} {rank}" if rank else ""
-                entries.append((display_name, pstats, rank_str, ""))
-                untracked_count += 1
 
         member_list = []
         for display_name, s, rank_str, rankup_str in entries:
@@ -561,7 +595,7 @@ class MatchTracker:
                 summary += f" · {tot_fk} FK / {tot_fd} FD"
             member_list.insert(0, summary)
 
-        squad_size = len(discord_members) + untracked_count
+        squad_size = len(discord_members) + len(unlinked_members)
 
         embed.add_field(
             name=f"👥 Squad ({squad_size})",
@@ -826,27 +860,41 @@ class MatchTracker:
         for match in matches_by_id.values():
             valorant_client.record_match_stats_for_players(match, list(member_puuids.keys()))
 
-        # Aggregate per-player stats and W/L across in-window matches
-        player_totals: Dict[int, Dict[str, Any]] = {}
+        # Aggregate per-player stats and W/L across in-window matches.
+        # Unlinked players on the stack's team count too — friends without
+        # /shootylink still show up, keyed by puuid and named by riot id.
+        player_totals: Dict[Any, Dict[str, Any]] = {}
         wins = losses = 0
         for match in matches_by_id.values():
             all_players = match.get('players', {}).get('all_players', [])
             teams = match.get('teams', {})
             stack_team = None
             for player in all_players:
-                if player.get('puuid') not in member_puuids:
-                    continue
-                member = member_puuids[player['puuid']]
+                if player.get('puuid') in member_puuids:
+                    stack_team = (player.get('team') or '').lower()
+                    break
+            for player in all_players:
+                puuid = player.get('puuid')
+                member = member_puuids.get(puuid)
+                if member is not None:
+                    key = member.id
+                    name = member.display_name
+                else:
+                    # Unlinked: only teammates, identified by in-game name#tag
+                    if not stack_team or (player.get('team') or '').lower() != stack_team:
+                        continue
+                    riot_name = player.get('name', 'Unknown')
+                    tag = player.get('tag', '')
+                    name = f"{riot_name}#{tag}" if tag else riot_name
+                    key = puuid or name
                 pstats = player.get('stats', {})
-                totals = player_totals.setdefault(member.id, {
-                    'member': member, 'kills': 0, 'deaths': 0, 'assists': 0, 'games': 0
+                totals = player_totals.setdefault(key, {
+                    'name': name, 'kills': 0, 'deaths': 0, 'assists': 0, 'games': 0
                 })
                 totals['kills'] += pstats.get('kills', 0)
                 totals['deaths'] += pstats.get('deaths', 0)
                 totals['assists'] += pstats.get('assists', 0)
                 totals['games'] += 1
-                if stack_team is None:
-                    stack_team = player.get('team', '').lower()
             if stack_team and stack_team in teams:
                 if teams[stack_team].get('has_won', False):
                     wins += 1
@@ -903,7 +951,7 @@ class MatchTracker:
             kda = (t['kills'] + t['assists']) / max(t['deaths'], 1)
             crown = "👑 " if i == 0 and len(ranked) > 1 else ""
             scoreboard.append(
-                f"{crown}**{t['member'].display_name}** — {t['kills']}/{t['deaths']}/{t['assists']} "
+                f"{crown}**{t['name']}** — {t['kills']}/{t['deaths']}/{t['assists']} "
                 f"({kda:.2f} KDA, {t['games']}G)"
             )
         embed.add_field(
@@ -915,7 +963,7 @@ class MatchTracker:
         if len(ranked) > 1:
             embed.add_field(
                 name="🌟 MVP of the Night",
-                value=f"**{ranked[0]['member'].display_name}** carried the squad! 🔥",
+                value=f"**{ranked[0]['name']}** carried the squad! 🔥",
                 inline=False
             )
 

--- a/tests/unit/test_rank_features.py
+++ b/tests/unit/test_rank_features.py
@@ -329,6 +329,58 @@ async def test_session_recap_with_games(discord_member_factory):
 
 
 @pytest.mark.asyncio
+async def test_session_recap_includes_unlinked_teammates(discord_member_factory):
+    """Players on the stack's team without a linked account still make the
+    session scoreboard (by riot name); enemies never do."""
+    bot = MagicMock(spec=discord.Client)
+    tracker = MatchTracker(bot)
+
+    m1 = discord_member_factory(user_id=1, name='Alice')
+    m1.bot = False
+    guild = MagicMock(spec=discord.Guild)
+
+    match = {
+        'metadata': {'matchid': 'm1', 'game_start': '2024-01-01T00:30:00Z'},
+        'teams': {'red': {'has_won': True}, 'blue': {'has_won': False}},
+        'players': {'all_players': [
+            {'puuid': 'pa', 'name': 'Alice', 'tag': 'NA1', 'team': 'Red',
+             'stats': {'kills': 12, 'deaths': 10, 'assists': 5}},
+            {'puuid': 'pu', 'name': 'UnlinkedBuddy', 'tag': '007', 'team': 'Red',
+             'stats': {'kills': 25, 'deaths': 5, 'assists': 9}},
+            {'puuid': 'pe', 'name': 'EnemyGuy', 'tag': 'KR1', 'team': 'Blue',
+             'stats': {'kills': 30, 'deaths': 12, 'assists': 2}},
+        ]},
+    }
+
+    fake_client = MagicMock()
+    fake_client.get_all_linked_accounts.side_effect = \
+        lambda uid: [{'username': 'Alice', 'tag': 'NA1', 'puuid': 'pa'}] if uid == 1 else []
+    fake_client.get_linked_account.side_effect = \
+        lambda uid: {'username': 'Alice', 'tag': 'NA1', 'puuid': 'pa'} if uid == 1 else None
+    fake_client.get_recent_competitive_updates = AsyncMock(return_value=[
+        {'match_id': 'm1',
+         'started_at': datetime(2024, 1, 1, 0, 30, tzinfo=timezone.utc),
+         'rr_change': 20}
+    ])
+    fake_client.get_match_details = AsyncMock(return_value=match)
+    fake_client.record_match_stats_for_players = MagicMock(return_value=1)
+    fake_client.get_mmr = AsyncMock(return_value=None)
+
+    session = _make_session('2024-01-01T00:00:00+00:00', '2024-01-01T02:00:00+00:00', 120)
+
+    with patch('match_tracker.valorant_client', fake_client):
+        embed = await tracker.build_session_recap(guild, [m1], session)
+
+    scoreboard = next(f for f in embed.fields if 'Scoreboard' in f.name)
+    assert 'Alice' in scoreboard.value
+    assert 'UnlinkedBuddy#007' in scoreboard.value
+    assert 'EnemyGuy' not in scoreboard.value
+    # The unlinked buddy has the best KDA and takes the crown/MVP
+    mvp = next(f for f in embed.fields if 'MVP' in f.name)
+    assert 'UnlinkedBuddy#007' in mvp.value
+
+
+@pytest.mark.asyncio
 async def test_session_recap_no_games(discord_member_factory):
     bot = MagicMock(spec=discord.Client)
     tracker = MatchTracker(bot)

--- a/tests/unit/test_untracked_squad_members.py
+++ b/tests/unit/test_untracked_squad_members.py
@@ -109,3 +109,115 @@ async def test_untracked_player_without_tag_falls_back_to_name(discord_member_fa
     squad_field = next(f for f in embed.fields if 'Squad' in f.name)
     assert 'NoTagPlayer' in squad_field.value
     assert 'NoTagPlayer#' not in squad_field.value
+
+
+def _three_stack_match():
+    """One tracked player and two same-team unlinked players, plus an enemy."""
+    return {
+        'metadata': {
+            'map': 'Ascent',
+            'rounds_played': 20,
+            'game_length': 1800,
+            'game_start': '2024-01-01T00:00:00Z',
+            'matchid': 'abc123',
+        },
+        'teams': {
+            'red': {'has_won': True, 'rounds_won': 13},
+            'blue': {'has_won': False, 'rounds_won': 7},
+        },
+        'players': {
+            'all_players': [
+                {'puuid': 'p1', 'name': 'TrackedPlayer', 'tag': 'NA1', 'team': 'Red',
+                 'character': 'Sage',
+                 'stats': {'kills': 10, 'deaths': 12, 'assists': 5, 'headshots': 5,
+                           'bodyshots': 20, 'legshots': 1, 'score': 3000},
+                 'damage_made': 2000, 'damage_received': 2500},
+                {'puuid': 'p2', 'name': 'UnlinkedCarry', 'tag': 'EU1', 'team': 'Red',
+                 'character': 'Jett',
+                 'stats': {'kills': 30, 'deaths': 8, 'assists': 2, 'headshots': 20,
+                           'bodyshots': 30, 'legshots': 0, 'score': 7000},
+                 'damage_made': 5000, 'damage_received': 1500},
+                {'puuid': 'enemy1', 'name': 'Enemy', 'tag': 'KR1', 'team': 'Blue',
+                 'character': 'Omen',
+                 'stats': {'kills': 40, 'deaths': 16, 'assists': 4, 'headshots': 30,
+                           'bodyshots': 10, 'legshots': 0, 'score': 9000},
+                 'damage_made': 8000, 'damage_received': 3000},
+            ],
+        },
+        'rounds': [],
+    }
+
+
+def _tracked_members(match, discord_member_factory):
+    member = discord_member_factory(user_id=1, name='TrackedDisplayName')
+    return [{
+        'member': member,
+        'account': {'puuid': 'p1'},
+        'player_data': match['players']['all_players'][0],
+    }]
+
+
+def test_unlinked_teammates_helper_builds_member_shaped_entries(discord_member_factory):
+    """_unlinked_teammates returns same-team unlinked players in the
+    discord_members dict shape, and never enemies."""
+    bot = MagicMock(spec=discord.Client)
+    tracker = MatchTracker(bot)
+    match = _three_stack_match()
+    discord_members = _tracked_members(match, discord_member_factory)
+
+    unlinked = tracker._unlinked_teammates(match, discord_members)
+
+    assert len(unlinked) == 1
+    entry = unlinked[0]
+    assert entry['member'].display_name == 'UnlinkedCarry#EU1'
+    assert entry['member'].id == 'p2'
+    assert entry['account']['puuid'] == 'p2'
+    assert entry['player_data']['puuid'] == 'p2'
+
+
+def test_unlinked_teammates_empty_without_team_info():
+    """Without any linked member team data we can't tell friend from foe."""
+    bot = MagicMock(spec=discord.Client)
+    tracker = MatchTracker(bot)
+    match = _three_stack_match()
+
+    assert tracker._unlinked_teammates(match, []) == []
+
+
+def test_fun_stats_include_unlinked_teammates(discord_member_factory):
+    """Highlights can feature unlinked teammates once they're in the roster."""
+    bot = MagicMock(spec=discord.Client)
+    tracker = MatchTracker(bot)
+    match = _three_stack_match()
+    discord_members = _tracked_members(match, discord_member_factory)
+    roster = discord_members + tracker._unlinked_teammates(match, discord_members)
+
+    stats = tracker._calculate_fun_match_stats(match, roster)
+    highlights = '\n'.join(stats['highlights'])
+
+    # The unlinked player is the clear top fragger and should be credited
+    assert 'UnlinkedCarry#EU1' in highlights
+    # The enemy team never shows up in highlights
+    assert 'Enemy#KR1' not in highlights
+
+
+@pytest.mark.asyncio
+async def test_match_embed_passes_unlinked_teammates_to_highlights(discord_member_factory):
+    """_create_match_embed computes highlights over linked + unlinked players."""
+    bot = MagicMock(spec=discord.Client)
+    tracker = MatchTracker(bot)
+    match = _three_stack_match()
+    discord_members = _tracked_members(match, discord_member_factory)
+
+    with patch('match_tracker.format_time_ago', return_value='just now'), \
+         patch.object(tracker, '_calculate_fun_match_stats',
+                      return_value={'highlights': [], 'top_performers': {}, 'funny_stats': {}}) as fun_mock:
+        embed = await tracker._create_match_embed(match, discord_members)
+
+    roster = fun_mock.call_args.args[1]
+    names = {dm['member'].display_name for dm in roster}
+    assert names == {'TrackedDisplayName', 'UnlinkedCarry#EU1'}
+
+    squad_field = next(f for f in embed.fields if 'Squad' in f.name)
+    assert 'Squad (2)' in squad_field.name
+    assert 'UnlinkedCarry#EU1' in squad_field.value


### PR DESCRIPTION
## Summary

People who play with the stack without linking a Valorant account (`/shootylink`) were missing from most of the post-match recap. The squad list already showed them, but they were invisible in two places:

- **Match highlights** only considered linked members — an unlinked friend's ace, clutch, or top-frag game never got a callout.
- **Session recap** — the Squad Scoreboard and MVP only aggregated linked players.

## Changes

- Added an `UnlinkedPlayer` stand-in exposing the `display_name`/`id` surface the recap code reads off `discord.Member` (its `id` is the puuid, so it can never collide with a real Discord member id), plus a `_unlinked_teammates()` helper that returns same-team unlinked players in the same dict shape as `discord_members` entries.
- `_create_match_embed` now runs linked + unlinked players through one loop for the squad list and passes the combined roster to `_calculate_fun_match_stats`, so highlights can feature everyone on the team. Enemies stay excluded; rank-up detection stays linked-only (it needs account data).
- `build_session_recap` aggregates every player on the stack's team across the session's matches — linked players by Discord name, unlinked ones by in-game `Name#tag` — and both are eligible for the scoreboard crown and MVP.

Note: the bot can't distinguish an unlinked friend from a random matchmade teammate, so everyone on the team shows up — the same policy the squad list already used, with the footer still nudging toward `/shootylink`.

## Testing

- 5 new unit tests: `_unlinked_teammates` shape/enemy exclusion, highlights featuring unlinked players, embed roster wiring, and session recap inclusion + MVP.
- Full suite: **306 passed, 3 skipped**. The only errors are pre-existing integration tests requiring live Henrik API access (blocked in the sandbox).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XjAuU3dYpxG24VxtcFdLXS

---
_Generated by [Claude Code](https://claude.ai/code/session_01XjAuU3dYpxG24VxtcFdLXS)_